### PR TITLE
Increase overall framerate while doing transitions

### DIFF
--- a/src/Framebuffer.ts
+++ b/src/Framebuffer.ts
@@ -260,7 +260,7 @@ export class Framebuffer {
      * @param  {number} c2
      * @return {number}     difference between c1 and c2 from 0-255
      */
-    public blend(c1: number, c2: number, nAlpha: number): number {
+    public static blend(c1: number, c2: number, nAlpha: number): number {
 
         if (0 === nAlpha) {
             return c1;
@@ -287,17 +287,17 @@ export class Framebuffer {
         return 0xff000000 | r << 16 | g << 8 | b;
     }
 
-    public drawTextureRect(xs: number, ys: number, xt: number, yt: number, width: number, height: number, texture: Texture, alpha2: number): void {
-        let texIndex = xt + yt * texture.width;
+    public drawTextureRect(xs: number, ys: number, xt: number, yt: number, width: number, height: number, texture: Uint32Array, pixelWidth: number,  alpha2: number): void {
+        let texIndex = xt + yt * pixelWidth;
         let frIndex = xs + ys * this.width;
 
         for (let h = 0; h < height; h++) {
             for (let w = 0; w < width; w++) {
-                const alpha = ((texture.texture[texIndex] >> 24) & 0xff) / 255 * alpha2;
+                const alpha = ((texture[texIndex] >> 24) & 0xff) / 255 * alpha2;
                 const inverseAlpha = 1 - alpha;
 
                 const fbPixel = this.framebuffer[frIndex];
-                const txPixel = texture.texture[texIndex];
+                const txPixel = texture[texIndex];
 
                 const r = (fbPixel >> 0 & 0xff) * inverseAlpha + (txPixel >> 0 & 0xff) * alpha;
                 const g = (fbPixel >> 8 & 0xff) * inverseAlpha + (txPixel >> 8 & 0xff) * alpha;
@@ -307,7 +307,7 @@ export class Framebuffer {
                 texIndex++;
                 frIndex++;
             }
-            texIndex += texture.width - width;
+            texIndex += pixelWidth - width;
             frIndex += this.width - width;
         }
     }
@@ -430,7 +430,7 @@ export class Framebuffer {
         const rng = new RandomNumberGenerator();
         rng.setSeed(elapsedTime);
         for (let y = 0; y < this.height; y++) {
-            this.drawTextureRect(0, y, Math.floor(rng.getFloat() * (texture.texture.length - this.width)), 0, this.width, 1, texture, scale);
+            this.drawTextureRect(0, y, Math.floor(rng.getFloat() * (texture.texture.length - this.width)), 0, this.width, 1, texture.texture, texture.width, scale);
         }
     }
 
@@ -1619,14 +1619,14 @@ export class Framebuffer {
         for (let j = 0; j < this.blenderObj4.length; j++) {
             const model = this.blenderObj4[j];
             if (j !== 0 && j !== 2) {
-                this.renderingPipeline.draw(model, mv);
+                this.renderingPipeline.draw(this, model, mv);
             }
 
             if (j === 0) {
-                this.renderingPipeline.draw(model, mv);
+                this.renderingPipeline.draw(this, model, mv);
             }
             if (j === 2) {
-                this.renderingPipeline.draw(model, mv);
+                this.renderingPipeline.draw(this, model, mv);
             }
 
         }
@@ -1638,7 +1638,7 @@ export class Framebuffer {
             ));
 
         const model2 = this.blenderObj5[0];
-        this.renderingPipeline.draw(model2, mv);
+        this.renderingPipeline.draw(this, model2, mv);
 
         const scale: number = 8;
         mv = camera.multiplyMatrix(
@@ -1693,7 +1693,7 @@ export class Framebuffer {
         modelViewMartrix = Matrix4f.constructZRotationMatrix(-elapsedTime * 0.02).multiplyMatrix(Matrix4f.constructTranslationMatrix(0, 0, -21)
             .multiplyMatrix(modelViewMartrix));
 
-        this.renderingPipeline.draw(this.torus.getMesh(), modelViewMartrix);
+        this.renderingPipeline.draw(this, this.torus.getMesh(), modelViewMartrix);
     }
 
     public torusFunction(alpha: number): Vector3f {

--- a/src/SkyBox.ts
+++ b/src/SkyBox.ts
@@ -99,7 +99,7 @@ export class SkyBox {
 
             framebuffer.setTexture(textures[i]);
             framebuffer.texturedRenderingPipeline.setModelViewMatrix(mv);
-            framebuffer.texturedRenderingPipeline.draw(skyBoxSideModel);
+            framebuffer.texturedRenderingPipeline.draw(framebuffer, skyBoxSideModel);
 
         }
 
@@ -140,7 +140,7 @@ export class SkyBox {
 
         framebuffer.setTexture(this.up);
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(mv);
-        framebuffer.texturedRenderingPipeline.draw(skyBoxSideModel);
+        framebuffer.texturedRenderingPipeline.draw(framebuffer, skyBoxSideModel);
 
 
         camera =
@@ -182,7 +182,7 @@ export class SkyBox {
 
         framebuffer.setTexture(this.down);
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(mv);
-        framebuffer.texturedRenderingPipeline.draw(skyBoxSideModel);
+        framebuffer.texturedRenderingPipeline.draw(framebuffer, skyBoxSideModel);
     }
 
 }

--- a/src/examples/abstract-cube/AbstractCube.ts
+++ b/src/examples/abstract-cube/AbstractCube.ts
@@ -64,7 +64,7 @@ export class AbstractCube extends AbstractScene {
 
         let mv: Matrix4f = camera.multiplyMatrix(Matrix4f.constructScaleMatrix(5, 16, 5));
         let model: FlatshadedMesh = this.scene[0];
-        this.renderingPipeline.draw(model, mv);
+        this.renderingPipeline.draw(framebuffer, model, mv);
 
         mv = camera.multiplyMatrix(Matrix4f.constructZRotationMatrix(
             Math.PI * 0.5 * framebuffer.cosineInterpolate(0, 600, Math.floor(elapsedTime * 0.7) % 4000))
@@ -72,7 +72,7 @@ export class AbstractCube extends AbstractScene {
                 Math.PI * 0.5 * framebuffer.cosineInterpolate(2000, 2600, Math.floor(elapsedTime * 0.7) % 4000)))
         );
         model = this.scene[1];
-        this.renderingPipeline.draw(model, mv);
+        this.renderingPipeline.draw(framebuffer, model, mv);
     }
 
 }

--- a/src/examples/baked-lighting/BakedLighting.ts
+++ b/src/examples/baked-lighting/BakedLighting.ts
@@ -80,7 +80,7 @@ export class BakedLighting extends AbstractScene {
         framebuffer.clearDepthBuffer();
         framebuffer.setTexture(this.baked);
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(mv);
-        framebuffer.texturedRenderingPipeline.drawMeshArray(this.blenderObj8);
+        framebuffer.texturedRenderingPipeline.drawMeshArray(framebuffer, this.blenderObj8);
     }
 
 }

--- a/src/examples/blender-camera-animation/WavefrontScene.ts
+++ b/src/examples/blender-camera-animation/WavefrontScene.ts
@@ -94,7 +94,7 @@ export class WavefrontScene extends AbstractScene {
         // TODO: use frame position for interpolation speed
         let faces: number= 0;
         for (let j = 0; j <this.meshes.length; j++) {
-            framebuffer.renderingPipeline.draw(this.meshes[j], modelViewMartrix);
+            framebuffer.renderingPipeline.draw(framebuffer, this.meshes[j], modelViewMartrix);
             faces += this.meshes[j].faces.length;
         }
 

--- a/src/examples/bunny/BunnyScene.ts
+++ b/src/examples/bunny/BunnyScene.ts
@@ -62,7 +62,7 @@ export class BunnyScene extends AbstractScene {
 
         const mv: Matrix4f = camera.multiplyMatrix(Matrix4f.constructScaleMatrix(10, 10, 10));
         const model: FlatshadedMesh = this.scene[0];
-        this.renderingPipeline.draw(model, mv);
+        this.renderingPipeline.draw(framebuffer, model, mv);
     }
 
     private constructSceneLights(): Array<PointLight> {

--- a/src/examples/cube-tunnel/CubeTunnelScene.ts
+++ b/src/examples/cube-tunnel/CubeTunnelScene.ts
@@ -76,7 +76,7 @@ export class CubeTunnelScene extends AbstractScene {
                 //       Matrix4f.constructYRotationMatrix(elapsedTime * 0.05)).multiplyMatrix(
                 //           Matrix4f.constructXRotationMatrix(elapsedTime * 0.08)));
 
-                this.renderingPipeline.draw(this.cubeMesh.getMesh(), mat);
+                this.renderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), mat);
             }
 
         }

--- a/src/examples/cube/CubeScene.ts
+++ b/src/examples/cube/CubeScene.ts
@@ -25,13 +25,13 @@ export class CubeScene extends AbstractScene {
         const elapsedTime: number = time * 0.02;
         framebuffer.clearColorBuffer(CubeScene.BACKGROUND_COLOR);
         framebuffer.clearDepthBuffer();
-        this.renderingPipeline.draw(this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime));
+        this.renderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime));
     }
 
     public renderBackground(framebuffer: Framebuffer, time: number): void {
         const elapsedTime: number = time * 0.02;
         framebuffer.clearDepthBuffer();
-        this.renderingPipeline.draw(this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime));
+        this.renderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime));
     }
 
     private getModelViewMatrix(elapsedTime: number): Matrix4f {

--- a/src/examples/different-md2/DifferentMd2ModelScene.ts
+++ b/src/examples/different-md2/DifferentMd2ModelScene.ts
@@ -58,7 +58,7 @@ export class DifferentMd2ModelScene extends AbstractScene {
 
         framebuffer.setTexture(this.ogroTexture);
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(this.modelViewMatrix.getMatrix());
-        framebuffer.texturedRenderingPipeline.draw(this.md2.getMesh(time));
+        framebuffer.texturedRenderingPipeline.draw(framebuffer, this.md2.getMesh(time));
     }
 
     private computeCameraMovement(elapsedTime: number): void {

--- a/src/examples/distorted-sphere/DistortedSphereScene.ts
+++ b/src/examples/distorted-sphere/DistortedSphereScene.ts
@@ -34,30 +34,23 @@ export class DistortedSphereScene extends AbstractScene {
 
     public render(framebuffer: Framebuffer, time: number): void {
         framebuffer.clearColorBuffer(Color.BLACK.toPackedFormat());
-        this.renderTransparent(framebuffer,time);
+        this.renderTransparent(framebuffer, time);
     }
-
 
     public renderTransparent(framebuffer: Framebuffer, time: number): void {
         framebuffer.setCullFace(CullFace.BACK);
-        /*
-        this.framebuffer.fastFramebufferCopy(this.framebuffer.framebuffer, this.blurred.texture);
-        // this.framebuffer.setBob(this.spheremap);
-        this.framebuffer.setBob(this.envmap);
-*/
         framebuffer.setTexture(this.env);
         const scale: number = 3.7;
-        const elapsedTime: number = (time) * 0.002;
 
         let modelViewMartrix = Matrix4f.constructScaleMatrix(scale, scale, scale)
-            .multiplyMatrix(Matrix4f.constructYRotationMatrix(elapsedTime * 0.35)
-                .multiplyMatrix(Matrix4f.constructXRotationMatrix(elapsedTime * 0.3)));
+            .multiplyMatrix(Matrix4f.constructYRotationMatrix(time * 0.0007)
+                .multiplyMatrix(Matrix4f.constructXRotationMatrix(time * 0.0006)));
 
         modelViewMartrix = Matrix4f.constructTranslationMatrix(-0, -0,
-            -10 - (Math.sin(elapsedTime * 0.3) * 0.5 + 0.5) * 6)
+            -10 - (Math.sin(time * 0.0006) * 0.5 + 0.5) * 6)
             .multiplyMatrix(modelViewMartrix);
         framebuffer.clearDepthBuffer();
-        this.shadingSphereEnvDisp2(framebuffer, time * 0.0002, modelViewMartrix);
+        this.shadingSphereEnvDisp2(framebuffer, time * 0.0000004, modelViewMartrix);
     }
 
     public createSphere() {
@@ -292,9 +285,9 @@ export class DistortedSphereScene extends AbstractScene {
                     v3.y > Framebuffer.maxWindow.y) {
 
 
-                    framebuffer.texturedRenderingPipeline.clipConvexPolygon2(vertexArray);
+                    framebuffer.texturedRenderingPipeline.clipConvexPolygon2(framebuffer, vertexArray);
                 } else {
-                    framebuffer.texturedTriangleRasterizer.drawTriangleDDA(vertexArray[0], vertexArray[1], vertexArray[2]);
+                    framebuffer.texturedTriangleRasterizer.drawTriangleDDA(framebuffer, vertexArray[0], vertexArray[1], vertexArray[2]);
                 }
             }
         }

--- a/src/examples/frustum-culling/FrustumCullingScene.ts
+++ b/src/examples/frustum-culling/FrustumCullingScene.ts
@@ -70,7 +70,7 @@ export class FrustumCullingScene extends AbstractScene {
             const model: [FlatshadedMesh, Sphere] = this.world[j];
 
             if (frustumCuller.isPotentiallyVisible(model[1])) {
-                this.renderingPipeline.draw(model[0], modelViewMartrix);
+                this.renderingPipeline.draw(framebuffer, model[0], modelViewMartrix);
                 const colLine = 255 << 24 | 255 << 8;
                 framebuffer.drawBoundingSphere(model[1], modelViewMartrix, colLine);
                 //  count++;

--- a/src/examples/gears-2/Gears2Scene.ts
+++ b/src/examples/gears-2/Gears2Scene.ts
@@ -77,8 +77,8 @@ export class Gears2Scene extends AbstractScene {
                 .multiplyMatrix(Matrix4f.constructZRotationMatrix(time * 0.0007).
                     multiplyMatrix(Matrix4f.constructXRotationMatrix(Math.PI * 2 / 360 * 90))));
 
-        this.renderingPipeline.draw(this.gearsMesh[0], mat);
-        this.renderingPipeline.draw(this.gearsMesh[0], mat2);
+        this.renderingPipeline.draw(framebuffer, this.gearsMesh[0], mat);
+        this.renderingPipeline.draw(framebuffer, this.gearsMesh[0], mat2);
     }
 
 

--- a/src/examples/gears/GearsScene.ts
+++ b/src/examples/gears/GearsScene.ts
@@ -74,7 +74,7 @@ export class GearsScene extends AbstractScene {
 
             const mv: Matrix4f = this.getModelViewMatrix(camera, dampFactor, scale, i, elapsedTime);
 
-            this.renderingPipeline.draw(this.gearsMesh[0], mv);
+            this.renderingPipeline.draw(framebuffer, this.gearsMesh[0], mv);
         }
         // let lensflareScreenSpace = framebuffer.project(camera.multiply(new Vector3f(16.0 * 20, 16.0 * 20, 0)));
         // framebuffer.drawLensFlare(lensflareScreenSpace, elapsedTime * 0.3, texture, dirt);

--- a/src/examples/hoodlum/HoodlumScene.ts
+++ b/src/examples/hoodlum/HoodlumScene.ts
@@ -67,7 +67,7 @@ export class HoodlumScene extends AbstractScene {
         let mv: Matrix4f = camera.multiplyMatrix(Matrix4f.constructScaleMatrix(13, 13, 13));
 
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(mv);
-        framebuffer.texturedRenderingPipeline.drawMeshArray(this.spaceLabMesh);
+        framebuffer.texturedRenderingPipeline.drawMeshArray(framebuffer, this.spaceLabMesh);
 
         mv = camera.multiplyMatrix(
             Matrix4f.constructTranslationMatrix(0, -5.5, 0).multiplyMatrix(
@@ -77,7 +77,7 @@ export class HoodlumScene extends AbstractScene {
             ));
 
         const model = this.hoodlumLogoMesh[0];
-        framebuffer.renderingPipeline.draw(model, mv);
+        framebuffer.renderingPipeline.draw(framebuffer, model, mv);
 
         const points: Array<Vector3f> = new Array<Vector3f>();
         const num = 10;

--- a/src/examples/md2/Md2ModelScene.ts
+++ b/src/examples/md2/Md2ModelScene.ts
@@ -59,7 +59,7 @@ export class Md2ModelScene extends AbstractScene {
 
         framebuffer.setTexture(this.ogroTexture);
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(this.modelViewMatrix.getMatrix());
-        framebuffer.texturedRenderingPipeline.draw(this.md2.getMesh(time));
+        framebuffer.texturedRenderingPipeline.draw(framebuffer, this.md2.getMesh(time));
     }
 
     private computeCameraMovement(elapsedTime: number): void {

--- a/src/examples/mdl/Md2ModelScene.ts
+++ b/src/examples/mdl/Md2ModelScene.ts
@@ -70,7 +70,7 @@ export class Md2ModelScene extends AbstractScene {
         this.computeCameraMovement(time * 0.6);
 
         framebuffer.setTexture(this.ogroTexture);
-        framebuffer.renderingPipeline.draw(this.meshes[0], this.modelViewMatrix.getMatrix());
+        framebuffer.renderingPipeline.draw(framebuffer, this.meshes[0], this.modelViewMatrix.getMatrix());
 
         framebuffer.drawText(8, 8, 'FPS: ' + this.fps.toString(), this.texture4);
         framebuffer.drawText(8, 16, 'FACES: ' + this.meshes[0].faces.length, this.texture4);

--- a/src/examples/metalheadz/MetalHeadzScene.ts
+++ b/src/examples/metalheadz/MetalHeadzScene.ts
@@ -69,7 +69,7 @@ export class MetalHeadzScene extends AbstractScene {
         const renderingPipeline: TexturingRenderingPipeline = framebuffer.texturedRenderingPipeline;
 
         renderingPipeline.setModelViewMatrix(mv);
-        renderingPipeline.drawMeshArray(this.blenderObjMetal);
+        renderingPipeline.drawMeshArray(framebuffer, this.blenderObjMetal);
 
         const scale: number = 20;
         const lensflareScreenSpace: Vector3f =

--- a/src/examples/moving-torus/MovingTorusScene.ts
+++ b/src/examples/moving-torus/MovingTorusScene.ts
@@ -44,7 +44,7 @@ export class MovingTorusScene extends AbstractScene {
         modelViewMartrix = Matrix4f.constructTranslationMatrix(Math.sin(elapsedTime * 0.04) * 25,
             Math.sin(elapsedTime * 0.05) * 9, -24).multiplyMatrix(modelViewMartrix);
 
-        framebuffer.renderingPipeline.draw(this.torus.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.torus.getMesh(), modelViewMartrix);
     }
 
 }

--- a/src/examples/pixel-effect/PixelEffectScene.ts
+++ b/src/examples/pixel-effect/PixelEffectScene.ts
@@ -62,7 +62,7 @@ export class PixelEffectScene extends AbstractScene {
     public render(framebuffer: Framebuffer, time: number): void {
         this.PlaneDeformationFloorScene.drawPlaneDeformation(framebuffer, time >> 3, 0);
 
-        this.fontRenderer2.drawText(0, framebuffer.height - 32 - 16,
+        this.fontRenderer2.drawText(framebuffer, 0, framebuffer.height - 32 - 16,
             '              WELCOME TO A NEW RELEASE FROM YOUR FRIENDS IN CRIME! HOW DO YOU LIKE THIS INTRO?'
             , (Date.now() - this.startTime) * 0.8, false);
 

--- a/src/examples/plane-deformation-floor/PlaneDeformationFloorScene.ts
+++ b/src/examples/plane-deformation-floor/PlaneDeformationFloorScene.ts
@@ -38,7 +38,7 @@ export class PlaneDeformationFloorScene extends AbstractScene {
 
     public render(framebuffer: Framebuffer, time: number): void {
         this.PlaneDeformationFloorScene.drawPlaneDeformation(framebuffer, time >> 3, 0);
-        this.fontRenderer2.drawText(0, framebuffer.height - 32 - 16,
+        this.fontRenderer2.drawText(framebuffer, 0, framebuffer.height - 32 - 16,
             '              WELCOME TO A NEW RELEASE FROM YOUR FRIENDS IN CRIME! HOW DO YOU LIKE THIS INTRO?'
             , (time - this.startTime) * 0.8, false);
         framebuffer.drawTexture((framebuffer.width/2)-(this.hoodlumLogo.width / 2), ((framebuffer.height / 2) - (this.hoodlumLogo.height / 2)) | 0, this.hoodlumLogo, 1.0);

--- a/src/examples/platonian/PlatonianScene.ts
+++ b/src/examples/platonian/PlatonianScene.ts
@@ -64,7 +64,7 @@ export class PlatonianScene extends AbstractScene {
 
         framebuffer.setTexture(this.platonian);
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(mv);
-        framebuffer.texturedRenderingPipeline.drawMeshArray(this.platonianMesh);
+        framebuffer.texturedRenderingPipeline.drawMeshArray(framebuffer, this.platonianMesh);
     }
 
 }

--- a/src/examples/razor/RazorScene.ts
+++ b/src/examples/razor/RazorScene.ts
@@ -81,7 +81,7 @@ export class RazorScene extends AbstractScene {
 
 
         let model = this.dodecahedron.getMesh();
-        framebuffer.renderingPipeline.draw(model, modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, model, modelViewMartrix);
 
         const yDisplacement = -1.5;
         const distance = 2.8;
@@ -91,7 +91,7 @@ export class RazorScene extends AbstractScene {
         modelViewMartrix = camera.multiplyMatrix(modelViewMartrix);
 
         model = this.icosahedron.getMesh();
-        framebuffer.renderingPipeline.draw(model, modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, model, modelViewMartrix);
 
         scale = 1.0;
         modelViewMartrix = Matrix4f.constructScaleMatrix(scale * 0.5, scale * 2, scale * 0.5);
@@ -100,7 +100,7 @@ export class RazorScene extends AbstractScene {
 
         // TODO:  store Mesh inside cube instance and use cube.draw(framebuffer);
         model = this.cube.getMesh();
-        framebuffer.renderingPipeline.draw(model, modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, model, modelViewMartrix);
 
         scale = 1.0;
         modelViewMartrix = Matrix4f.constructScaleMatrix(scale, scale, scale);
@@ -108,7 +108,7 @@ export class RazorScene extends AbstractScene {
         modelViewMartrix = camera.multiplyMatrix(modelViewMartrix);
 
         model = this.cube.getMesh();
-        framebuffer.renderingPipeline.draw(model, modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, model, modelViewMartrix);
 
         scale = 1.0;
         modelViewMartrix = Matrix4f.constructScaleMatrix(scale, scale, scale);
@@ -116,7 +116,7 @@ export class RazorScene extends AbstractScene {
         modelViewMartrix = camera.multiplyMatrix(modelViewMartrix);
 
         model = this.pyramid.getMesh();
-        framebuffer.renderingPipeline.draw(model, modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, model, modelViewMartrix);
 
         /**
          * SHADOWS
@@ -130,7 +130,7 @@ export class RazorScene extends AbstractScene {
         modelViewMartrix = camera.multiplyMatrix(
             Matrix4f.constructShadowMatrix(modelViewMartrix).multiplyMatrix(modelViewMartrix));
 
-        framebuffer.renderingPipeline.draw(this.dodecahedron.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.dodecahedron.getMesh(), modelViewMartrix);
 
         scale = 1.0;
         modelViewMartrix = Matrix4f.constructScaleMatrix(scale, scale, scale);
@@ -138,7 +138,7 @@ export class RazorScene extends AbstractScene {
         modelViewMartrix = camera.multiplyMatrix(
             Matrix4f.constructShadowMatrix(modelViewMartrix).multiplyMatrix(modelViewMartrix));
 
-        framebuffer.renderingPipeline.draw(this.pyramid.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.pyramid.getMesh(), modelViewMartrix);
 
         scale = 1.0;
         modelViewMartrix = Matrix4f.constructScaleMatrix(scale, scale, scale);
@@ -146,7 +146,7 @@ export class RazorScene extends AbstractScene {
         modelViewMartrix = camera.multiplyMatrix(
             Matrix4f.constructShadowMatrix(modelViewMartrix).multiplyMatrix(modelViewMartrix));
 
-        framebuffer.renderingPipeline.draw(this.cube.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.cube.getMesh(), modelViewMartrix);
 
         scale = 1.0;
         modelViewMartrix = Matrix4f.constructScaleMatrix(scale * 0.5, scale * 2, scale * 0.5);
@@ -154,7 +154,7 @@ export class RazorScene extends AbstractScene {
         modelViewMartrix = camera.multiplyMatrix(
             Matrix4f.constructShadowMatrix(modelViewMartrix).multiplyMatrix(modelViewMartrix));
 
-        framebuffer.renderingPipeline.draw(this.cube.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.cube.getMesh(), modelViewMartrix);
 
         scale = 1.0;
         modelViewMartrix = Matrix4f.constructScaleMatrix(scale, scale, scale);
@@ -162,7 +162,7 @@ export class RazorScene extends AbstractScene {
         modelViewMartrix = camera.multiplyMatrix(
             Matrix4f.constructShadowMatrix(modelViewMartrix).multiplyMatrix(modelViewMartrix));
 
-        framebuffer.renderingPipeline.draw(this.icosahedron.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.icosahedron.getMesh(), modelViewMartrix);
 
         framebuffer.renderingPipeline.enableLighting(true);
 

--- a/src/examples/rotating-gears/RotatingGearsScene.ts
+++ b/src/examples/rotating-gears/RotatingGearsScene.ts
@@ -84,7 +84,7 @@ export class RotatingGearsScene extends AbstractScene {
                     )
                 )
             );
-            this.renderingPipeline.draw(this.gearsMesh[0], mv);
+            this.renderingPipeline.draw(framebuffer, this.gearsMesh[0], mv);
         }
         // let lensflareScreenSpace = framebuffer.project(camera.multiply(new Vector3f(16.0 * 20, 16.0 * 20, 0)));
         // framebuffer.drawLensFlare(lensflareScreenSpace, elapsedTime * 0.3, texture, dirt);

--- a/src/examples/sine-scroller/FontRenderer.ts
+++ b/src/examples/sine-scroller/FontRenderer.ts
@@ -45,7 +45,7 @@ export class FontRenderer {
         }
     }
 
-    public drawText(x: number, y: number, text: string, time: number, sine: boolean = true): void {
+    public drawText(framebuffer: Framebuffer, x: number, y: number, text: string, time: number, sine: boolean = true): void {
         let xpos: number = x;
         const xFonts: number = this.fontTexture.width / this.width;
 
@@ -58,26 +58,26 @@ export class FontRenderer {
             const index: number = this.charToIndex.has(asciiCode) ? this.charToIndex.get(asciiCode) : 0;
             const tx: number = Math.floor(index % xFonts) * this.width;
             const ty: number = Math.floor(index / xFonts) * this.height;
-            this.drawTextureRectFastAlpha(xpos,
+            this.drawTextureRectFastAlpha(framebuffer, xpos,
                 y, tx, ty, this.width, this.height, this.fontTexture, time, sine);
             xpos += this.width;
         }
     }
 
-    public drawTextureRectFastAlpha(xs: number, ys: number, xt: number, yt: number,
+    public drawTextureRectFastAlpha(framebuffer: Framebuffer, xs: number, ys: number, xt: number, yt: number,
         width: number, height: number, texture: Texture, time: number, sine: boolean = true): void {
         const startW: number = Math.max(0, 0 - xs);
-        const endW: number = Math.min(xs + width, this.framebuffer.width) - xs;
+        const endW: number = Math.min(xs + width, framebuffer.width) - xs;
         for (let w: number = startW; w < endW; w++) {
 
             const yDisp: number = sine ? Math.round(Math.sin(time * 0.004 + (xs + w) * 0.013) * 30) : 0;
             let texIndex: number = xt + w + yt * texture.width;
-            let frIndex: number = xs + w + (ys + yDisp) * this.framebuffer.width;
+            let frIndex: number = xs + w + (ys + yDisp) * framebuffer.width;
 
             for (let h: number = 0; h < height; h++) {
                 const color: number = texture.texture[texIndex];
                 if (color & 0xff000000) {
-                    this.framebuffer.framebuffer[frIndex] = color;
+                    framebuffer.framebuffer[frIndex] = color;
                 }
 
                 texIndex += texture.width;

--- a/src/examples/sine-scroller/SineScrollerScene.ts
+++ b/src/examples/sine-scroller/SineScrollerScene.ts
@@ -67,8 +67,8 @@ export class SineScrollerScene extends AbstractScene {
 
         framebuffer.drawTexture(0, 0, this.texture2, 1.0);
 
-        this.fontRenderer.drawText(0, 102, ' # TEAM GENESIS # IS BACK IN 2018 WITH A NEW PC FIRST! \'STAR WARS - EMPIRE AT WAR\' DO YOU LIKE THIS?    ', time);
-        this.fontRenderer2.drawText(0, framebuffer.height - 20,
+        this.fontRenderer.drawText(framebuffer, 0, 102, ' # TEAM GENESIS # IS BACK IN 2018 WITH A NEW PC FIRST! \'STAR WARS - EMPIRE AT WAR\' DO YOU LIKE THIS?    ', time);
+        this.fontRenderer2.drawText(framebuffer, 0, framebuffer.height - 20,
             '   * WE REALLY LOVE SCROLLERS * HOW ABOUT YOU? THIS PRODUCTION IS FROM HOODLUM' +
             '~< LETS GO ON WITH THE GENERAL BLAH BLAH      ', time * 1.6, false);
 

--- a/src/examples/textured-torus/TexturedTorusScene.ts
+++ b/src/examples/textured-torus/TexturedTorusScene.ts
@@ -47,7 +47,7 @@ export class TexturedTorusScene extends AbstractScene {
             .multiplyMatrix(modelViewMartrix);
 
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(modelViewMartrix);
-        framebuffer.texturedRenderingPipeline.draw(this.torusMesh);
+        framebuffer.texturedRenderingPipeline.draw(framebuffer, this.torusMesh);
     }
 
 

--- a/src/examples/third-person-camera/ThirdPersonCameraScene.ts
+++ b/src/examples/third-person-camera/ThirdPersonCameraScene.ts
@@ -215,7 +215,7 @@ export class ThirdPersonCameraScene extends AbstractScene {
         this.texturedRenderingPipeline.setCullFace(CullFace.BACK);
         this.computeFloorMovement(delta);
         this.texturedRenderingPipeline.setModelViewMatrix(this.modelViewMatrix.getMatrix());
-        this.texturedRenderingPipeline.draw(this.floor);
+        this.texturedRenderingPipeline.draw(framebuffer, this.floor);
         this.modelViewMatrix.trans(0, 0.1, 0);
 
         this.computeGlowMovement(delta, currentTime);
@@ -223,7 +223,7 @@ export class ThirdPersonCameraScene extends AbstractScene {
 
         this.texturedRenderingPipeline.enableAlphaBlending();
         this.texturedRenderingPipeline.setModelViewMatrix(this.modelViewMatrix.getMatrix());
-        this.texturedRenderingPipeline.draw(this.floor);
+        this.texturedRenderingPipeline.draw(framebuffer, this.floor);
         this.texturedRenderingPipeline.disableAlphaBlending();
 
         this.texturedRenderingPipeline.setCullFace(CullFace.FRONT);
@@ -244,10 +244,10 @@ export class ThirdPersonCameraScene extends AbstractScene {
         this.texturedRenderingPipeline.setModelViewMatrix(this.modelViewMatrix.getMatrix());
 
         framebuffer.setTexture(this.ogroTexture);
-        this.texturedRenderingPipeline.draw(this.md2.getMesh2(time * 1000));
+        this.texturedRenderingPipeline.draw(framebuffer, this.md2.getMesh2(time * 1000));
 
         framebuffer.setTexture(this.weaponTexture);
-        this.texturedRenderingPipeline.draw(this.weapon.getMesh2(time * 1000));
+        this.texturedRenderingPipeline.draw(framebuffer, this.weapon.getMesh2(time * 1000));
     }
 
     private computeFloorMovement(elapsedTime: number): void {

--- a/src/examples/torus-knot-tunnel/TorusKnotTunnelScene.ts
+++ b/src/examples/torus-knot-tunnel/TorusKnotTunnelScene.ts
@@ -55,20 +55,26 @@ export class TorusKnotTunnelScene extends AbstractScene {
         texture2.height = framebuffer.height;
         texture2.width = framebuffer.width;
         texture2.texture = framebuffer.framebuffer;
-        for (let x = 0; x < 16; x++) {
-            for (let y = 0; y < 10; y++) {
+
+
+        const blockWidth = 20;
+        const horizontalUnits = Math.floor(framebuffer.width / blockWidth);
+        const verticalUnits = Math.floor(framebuffer.height / blockWidth);
+
+        for (let x = 0; x < horizontalUnits; x++) {
+            for (let y = 0; y < verticalUnits; y++) {
                 if (rng.getFloat() > 0.25) {
                     continue;
                 }
 
-                framebuffer.drawTextureRect(20 * (16 - x), 20 * ((16 * rng.getFloat()) | 0), 20 * x, 20 * y, 20, 20, texture2, 0.03 + 0.35 * glitchFactor);
+                framebuffer.drawTextureRect(blockWidth * (horizontalUnits - x), blockWidth * ((horizontalUnits * rng.getFloat()) | 0), blockWidth * x, blockWidth * y, blockWidth, blockWidth, texture2.texture, texture2.width, 0.03 + 0.35 * glitchFactor);
             }
         }
 
         if (noise) {
-            for (let x = 0; x < 16; x++) {
-                for (let y = 0; y < 10; y++) {
-                    framebuffer.drawTextureRect(x * 20, y * 20, 20 * (Math.round(elapsedTime / 100 + x + y) % 12), 0, 20, 20, texture, 0.1 + 0.3 * glitchFactor);
+            for (let x = 0; x < horizontalUnits; x++) {
+                for (let y = 0; y < verticalUnits; y++) {
+                    framebuffer.drawTextureRect(x * blockWidth, y * blockWidth, blockWidth * (Math.round(elapsedTime / 100 + x + y) % 12), 0, blockWidth, blockWidth, texture.texture, texture.width, 0.1 + 0.3 * glitchFactor);
                 }
             }
         }
@@ -149,7 +155,7 @@ export class TorusKnotTunnelScene extends AbstractScene {
         modelViewMartrix = Matrix4f.constructTranslationMatrix(0, 0, -10).multiplyMatrix(modelViewMartrix.multiplyMatrix(Matrix4f.constructXRotationMatrix(elapsedTime * 0.04)));
         modelViewMartrix = Matrix4f.constructZRotationMatrix(elapsedTime * 0.01).multiplyMatrix(finalMatrix);
 
-        framebuffer.renderingPipeline.draw(this.torusKnot.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.torusKnot.getMesh(), modelViewMartrix);
     }
 
     private torusFunction3(alpha: number): Vector4f {

--- a/src/examples/torus-knot/TorusKnotScene.ts
+++ b/src/examples/torus-knot/TorusKnotScene.ts
@@ -79,14 +79,14 @@ export class TorusKnotScene extends AbstractScene {
                     continue;
                 }
 
-                framebuffer.drawTextureRect(20 * (16 - x), 20 * ((16 * rng.getFloat()) | 0), 20 * x, 20 * y, 20, 20, texture2, 0.1 + 0.35 * glitchFactor);
+                framebuffer.drawTextureRect(20 * (16 - x), 20 * ((16 * rng.getFloat()) | 0), 20 * x, 20 * y, 20, 20, texture2.texture, texture2.width, 0.1 + 0.35 * glitchFactor);
             }
         }
 
         if (noise) {
             for (let x = 0; x < 16; x++) {
                 for (let y = 0; y < 10; y++) {
-                    framebuffer.drawTextureRect(x * 20, y * 20, 20 * (Math.round(elapsedTime / 100 + x + y) % 12), 0, 20, 20, texture, 0.1 + 0.3 * glitchFactor);
+                    framebuffer.drawTextureRect(x * 20, y * 20, 20 * (Math.round(elapsedTime / 100 + x + y) % 12), 0, 20, 20, texture.texture, texture.width, 0.1 + 0.3 * glitchFactor);
                 }
             }
         }
@@ -144,7 +144,7 @@ export class TorusKnotScene extends AbstractScene {
         modelViewMartrix = Matrix4f.constructTranslationMatrix(Math.sin(time * 0.04) * 20,
             Math.sin(time * 0.05) * 8 - smash * 5, -28 - 250).multiplyMatrix(modelViewMartrix);
 
-        framebuffer.renderingPipeline.draw(this.torus.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.torus.getMesh(), modelViewMartrix);
     }
 
 }

--- a/src/examples/torus/TorusScene.ts
+++ b/src/examples/torus/TorusScene.ts
@@ -35,7 +35,7 @@ export class TorusScene extends AbstractScene {
         modelViewMartrix = modelViewMartrix.multiplyMatrix(Matrix4f.constructXRotationMatrix(elapsedTime * 0.08));
         modelViewMartrix = Matrix4f.constructTranslationMatrix(0, 0, -24).multiplyMatrix(modelViewMartrix);
 
-        framebuffer.renderingPipeline.draw(this.torus.getMesh(), modelViewMartrix);
+        framebuffer.renderingPipeline.draw(framebuffer, this.torus.getMesh(), modelViewMartrix);
     }
 
 

--- a/src/examples/tunnel/TunnelScene.ts
+++ b/src/examples/tunnel/TunnelScene.ts
@@ -40,7 +40,7 @@ export class TunnelScene extends AbstractScene {
         framebuffer.setTexture(this.metalheadz);
 
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(mv);
-        framebuffer.texturedRenderingPipeline.drawMeshArray(this.blenderObjMetal);
+        framebuffer.texturedRenderingPipeline.drawMeshArray(framebuffer, this.blenderObjMetal);
 
         const texture3: Texture = new Texture(this.accumulationBuffer, framebuffer.width, framebuffer.height);
         framebuffer.drawTexture(0, 0, texture3, 0.75);

--- a/src/examples/voxel-balls/VoxelBallsScene.ts
+++ b/src/examples/voxel-balls/VoxelBallsScene.ts
@@ -65,7 +65,7 @@ export class VoxelBallsScene extends AbstractScene {
                     //       Matrix4f.constructYRotationMatrix(elapsedTime * 0.05)).multiplyMatrix(
                     //           Matrix4f.constructXRotationMatrix(elapsedTime * 0.08)));
 
-                    this.renderingPipeline.draw(this.cubeMesh.getMesh(), mat);
+                    this.renderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), mat);
                 }
             }
         }

--- a/src/examples/voxel-landscape-fade/VoxelLandcapeFadeScene.ts
+++ b/src/examples/voxel-landscape-fade/VoxelLandcapeFadeScene.ts
@@ -190,7 +190,7 @@ export class VoxelLandScapeFadeScene extends AbstractScene {
             let texel: number;
 
             // fade out to the distance
-            texel = framebuffer.blend(this.texelMap[idx], 0xFF000000, i);
+            texel = Framebuffer.blend(this.texelMap[idx], 0xFF000000, i);
             // texel = this.texelMap[idx];
 
             // while (hi > z && j3 > 0) {

--- a/src/examples/wavefront-texture/WaveFrontTextureScene.ts
+++ b/src/examples/wavefront-texture/WaveFrontTextureScene.ts
@@ -36,7 +36,7 @@ export class WaveFrontTextureScene extends AbstractScene {
 
         framebuffer.setTexture(this.platonian);
         framebuffer.texturedRenderingPipeline.setModelViewMatrix(this.getModelViewMatrix(elapsedTime));
-        framebuffer.texturedRenderingPipeline.drawMeshArray(this.platonianMesh);
+        framebuffer.texturedRenderingPipeline.drawMeshArray(framebuffer, this.platonianMesh);
     }
 
     private getModelViewMatrix(elapsedTime: number): Matrix4f {

--- a/src/examples/wavefront/WavefrontScene.ts
+++ b/src/examples/wavefront/WavefrontScene.ts
@@ -69,7 +69,7 @@ export class WavefrontScene extends AbstractScene {
 
         this.computeCameraMovement(time * 0.6);
 
-        framebuffer.renderingPipeline.draw(this.meshes[0], this.modelViewMatrix.getMatrix());
+        framebuffer.renderingPipeline.draw(framebuffer, this.meshes[0], this.modelViewMatrix.getMatrix());
 
         framebuffer.drawText(8, 8, 'FPS: ' + this.fps.toString(), this.texture4);
         framebuffer.drawText(8, 16, 'FACES: ' + this.meshes[0].faces.length, this.texture4);

--- a/src/model/wavefront-obj/TexturedMeshGroup.ts
+++ b/src/model/wavefront-obj/TexturedMeshGroup.ts
@@ -1,3 +1,4 @@
+import { Framebuffer } from '../../Framebuffer';
 import { Matrix4f } from '../../math';
 import { TexturedMesh } from '../../rendering-pipelines/TexturedMesh';
 import { TexturingRenderingPipeline } from '../../rendering-pipelines/TexturingRenderingPipeline';
@@ -7,8 +8,8 @@ class TexturedMeshGroup {
     constructor(private meshes: Array<TexturedMesh>, private pipeline: TexturingRenderingPipeline) {
     }
 
-    public draw(mv: Matrix4f): void {
-        this.pipeline.drawMeshArray(this.meshes);
+    public draw(framebuffer: Framebuffer, mv: Matrix4f): void {
+        this.pipeline.drawMeshArray(framebuffer, this.meshes);
     }
 
 }

--- a/src/rasterizer/AbstractTriangleRasterizer.ts
+++ b/src/rasterizer/AbstractTriangleRasterizer.ts
@@ -1,7 +1,8 @@
+import { Framebuffer } from '../Framebuffer';
 import { Vertex } from '../Vertex';
 
 export abstract class AbstractTriangleRasterizer {
 
-    public abstract drawTriangleDDA(p1: Vertex, p2: Vertex, p3: Vertex): void;
+    public abstract drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void;
 
 }

--- a/src/rasterizer/FlatShadingTriangleRasterizer.ts
+++ b/src/rasterizer/FlatShadingTriangleRasterizer.ts
@@ -14,7 +14,7 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
      * Triangle rasterization using edge-walking strategy for scan-conversion.
      * Internally DDA is used for edge-walking.
      */
-    public drawTriangleDDA(p1: Vertex, p2: Vertex, p3: Vertex): void {
+    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
         if (p1.projection.y > p3.projection.y) {
             this.temp = p1;
             p1 = p3;
@@ -41,26 +41,26 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
                 p2 = p3;
                 p3 = this.temp;
             }
-            this.fillBottomFlatTriangle(p1, p2, p3);
+            this.fillBottomFlatTriangle(framebuffer, p1, p2, p3);
         } else if (p1.projection.y === p2.projection.y) {
             if (p1.projection.x > p2.projection.x) {
                 this.temp = p1;
                 p1 = p2;
                 p2 = this.temp;
             }
-            this.fillTopFlatTriangle(p1, p2, p3);
+            this.fillTopFlatTriangle(framebuffer, p1, p2, p3);
         } else {
             const x: number = (p3.projection.x - p1.projection.x) *
                 (p2.projection.y - p1.projection.y) / (p3.projection.y - p1.projection.y) + p1.projection.x;
             if (x > p2.projection.x) {
-                this.fillLongRightTriangle(p1, p2, p3);
+                this.fillLongRightTriangle(framebuffer, p1, p2, p3);
             } else {
-                this.fillLongLeftTriangle(p1, p2, p3);
+                this.fillLongLeftTriangle(framebuffer, p1, p2, p3);
             }
         }
     }
 
-    private fillBottomFlatTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    private fillBottomFlatTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         const color: number = v1.color.toPackedFormat();
 
         const yDistance: number = v3.projection.y - v1.projection.y;
@@ -101,7 +101,7 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
         }
     }
 
-    fillTopFlatTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    fillTopFlatTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         const color: number = v1.color.toPackedFormat();
 
         const yDistance = v3.projection.y - v1.projection.y;
@@ -139,7 +139,7 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
         }
     }
 
-    fillLongRightTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    fillLongRightTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         const color: number = v1.color.toPackedFormat();
 
         let yDistanceLeft = v2.projection.y - v1.projection.y;
@@ -211,7 +211,7 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
     }
 
 
-    fillLongLeftTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    fillLongLeftTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         const color: number = v1.color.toPackedFormat();
 
         let yDistanceRight = v2.projection.y - v1.projection.y;

--- a/src/rasterizer/GouraudShadingTriangleRasterizer.ts
+++ b/src/rasterizer/GouraudShadingTriangleRasterizer.ts
@@ -20,7 +20,7 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
      * Triangle rasterization using edge-walking strategy for scan-conversion.
      * Internally DDA is used for edge-walking.
      */
-    public drawTriangleDDA(p1: Vertex, p2: Vertex, p3: Vertex): void {
+    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
         if (p1.projection.y > p3.projection.y) {
             this.temp = p1;
             p1 = p3;
@@ -47,26 +47,26 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
                 p2 = p3;
                 p3 = this.temp;
             }
-            this.fillBottomFlatTriangle(p1, p2, p3);
+            this.fillBottomFlatTriangle(framebuffer, p1, p2, p3);
         } else if (p1.projection.y === p2.projection.y) {
             if (p1.projection.x > p2.projection.x) {
                 this.temp = p1;
                 p1 = p2;
                 p2 = this.temp;
             }
-            this.fillTopFlatTriangle(p1, p2, p3);
+            this.fillTopFlatTriangle(framebuffer, p1, p2, p3);
         } else {
             const x: number = (p3.projection.x - p1.projection.x) *
                 (p2.projection.y - p1.projection.y) / (p3.projection.y - p1.projection.y) + p1.projection.x;
             if (x > p2.projection.x) {
-                this.fillLongRightTriangle(p1, p2, p3);
+                this.fillLongRightTriangle(framebuffer, p1, p2, p3);
             } else {
-                this.fillLongLeftTriangle(p1, p2, p3);
+                this.fillLongLeftTriangle(framebuffer, p1, p2, p3);
             }
         }
     }
 
-    private fillBottomFlatTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    private fillBottomFlatTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         const yDistance: number = v3.projection.y - v1.projection.y;
 
         const slope1: number = (v2.projection.x - v1.projection.x) / yDistance;
@@ -89,13 +89,13 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
             const length = Math.round(xPosition2) - Math.round(xPosition);
             this.rowColorInterpolator.setup(
                 this.colorInterpolator1.startColor, this.colorInterpolator2.startColor, length);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition);
             const spanzStep = (curz2 - curz1) / length;
             let wStart = curz1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] =
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
+                    framebuffer.framebuffer[framebufferIndex] =
                         this.rowColorInterpolator.startColor.toPackedFormat();
                 }
                 framebufferIndex++;
@@ -122,7 +122,7 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
         }
     }
 
-    private fillTopFlatTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    private fillTopFlatTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         const yDistance = v3.projection.y - v1.projection.y;
         const slope1 = (v3.projection.x - v1.projection.x) / yDistance;
         const slope2 = (v3.projection.x - v2.projection.x) / yDistance;
@@ -145,12 +145,12 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
             const length = Math.round(xPosition2) - Math.round(xPosition);
             this.rowColorInterpolator.setup(
                 this.colorInterpolator1.startColor, this.colorInterpolator2.startColor, length);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition);
             for (let j = 0; j < length; j++) {
                 const wStart = (curz2 - curz1) / (length) * j + curz1;
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
+                    framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
                 }
                 framebufferIndex++;
                 this.rowColorInterpolator.startColor.r += this.rowColorInterpolator.colorSlope.r;
@@ -175,7 +175,7 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
         }
     }
 
-    private fillLongRightTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    private fillLongRightTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         let yDistanceLeft = v2.projection.y - v1.projection.y;
         const yDistanceRight = v3.projection.y - v1.projection.y;
 
@@ -200,13 +200,13 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
             const length = Math.round(xPosition2) - Math.round(xPosition);
             this.rowColorInterpolator.setup(
                 this.colorInterpolator1.startColor, this.colorInterpolator2.startColor, length);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition);
             const spanzStep = (curz2 - curz1) / length;
             let wStart = curz1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
+                    framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
                 }
                 framebufferIndex++;
                 wStart += spanzStep;
@@ -243,13 +243,13 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
             const length = Math.round(xPosition2) - Math.round(xPosition);
             this.rowColorInterpolator.setup(
                 this.colorInterpolator3.startColor, this.colorInterpolator2.startColor, length);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition);
             const spanzStep = (curz2 - curz1) / length;
             let wStart = curz1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
+                    framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
                 }
                 framebufferIndex++;
                 wStart += spanzStep;
@@ -276,7 +276,7 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
     }
 
 
-    fillLongLeftTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    fillLongLeftTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         let yDistanceRight = v2.projection.y - v1.projection.y;
         const yDistanceLeft = v3.projection.y - v1.projection.y;
 
@@ -300,13 +300,13 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
             const length = Math.round(xPosition2) - Math.round(xPosition);
             this.rowColorInterpolator.setup(
                 this.colorInterpolator1.startColor, this.colorInterpolator2.startColor, length);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition);
             const spanzStep = (curz2 - curz1) / length;
             let wStart = curz1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
+                    framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
                 }
                 framebufferIndex++;
                 wStart += spanzStep;
@@ -343,13 +343,13 @@ export class GouraudShadingTriangleRasterizer extends AbstractTriangleRasterizer
             const length = Math.round(xPosition2) - Math.round(xPosition);
             this.rowColorInterpolator.setup(
                 this.colorInterpolator1.startColor, this.colorInterpolator3.startColor, length);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition)
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition)
             const spanzStep = (curz2 - curz1) / length;
             let wStart = curz1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
+                    framebuffer.framebuffer[framebufferIndex] = this.rowColorInterpolator.startColor.toPackedFormat();
                 }
                 framebufferIndex++;
                 wStart += spanzStep;

--- a/src/rasterizer/TexturedAlphaBlendingTriangleRasterizer.ts
+++ b/src/rasterizer/TexturedAlphaBlendingTriangleRasterizer.ts
@@ -12,7 +12,7 @@ export class TexturedAlphaBlendingTriangleRasterizer {
     // bob und wbuffer
     constructor(private framebuffer: Framebuffer, private pipeline: AbstractRenderingPipeline) { }
 
-    public drawTriangleDDA(p1: Vertex, p2: Vertex, p3: Vertex): void {
+    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
 
         if (p1.position.y > p3.position.y) {
             this.temp = p1;
@@ -38,13 +38,14 @@ export class TexturedAlphaBlendingTriangleRasterizer {
             const x: number = (p3.position.x - p1.position.x) * (p2.position.y - p1.position.y) /
                 (p3.position.y - p1.position.y) + p1.position.x;
             if (x > p2.position.x) {
-                this.fillLongRightTriangle2(p1, p2, p3);
+                this.fillLongRightTriangle2(framebuffer, p1, p2, p3);
             } else {
                 const tex = p1.textureCoordinate;
                 const tex2 = p2.textureCoordinate;
                 const tex3 = p3.textureCoordinate;
 
                 this.fillLongLeftTriangle2(
+                    framebuffer,
                     p1.position,
                     p2.position,
                     p3.position,
@@ -56,7 +57,7 @@ export class TexturedAlphaBlendingTriangleRasterizer {
         }
     }
 
-    private fillLongRightTriangle2(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    private fillLongRightTriangle2(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         let yDistanceLeft = v2.position.y - v1.position.y;
 
 
@@ -212,7 +213,7 @@ export class TexturedAlphaBlendingTriangleRasterizer {
     }
 
 
-    fillLongLeftTriangle2(v1: Vector4f, v2: Vector4f, v3: Vector4f, t1: Vector3f, t2: Vector3f, t3: Vector3f): void {
+    fillLongLeftTriangle2(framebuffer: Framebuffer, v1: Vector4f, v2: Vector4f, v3: Vector4f, t1: Vector3f, t2: Vector3f, t3: Vector3f): void {
 
         let yDistanceRight = v2.y - v1.y;
         const yDistanceLeft = v3.y - v1.y;

--- a/src/rasterizer/TexturedTriangleRasterizer.ts
+++ b/src/rasterizer/TexturedTriangleRasterizer.ts
@@ -11,7 +11,7 @@ export class TexturedTriangleRasterizer {
     // bob und wbuffer
     constructor(private framebuffer: Framebuffer) { }
 
-    public drawTriangleDDA(p1: Vertex, p2: Vertex, p3: Vertex): void {
+    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
 
         if (p1.position.y > p3.position.y) {
             this.temp = p1;
@@ -37,13 +37,14 @@ export class TexturedTriangleRasterizer {
             const x: number = (p3.position.x - p1.position.x) * (p2.position.y - p1.position.y) /
                 (p3.position.y - p1.position.y) + p1.position.x;
             if (x > p2.position.x) {
-                this.fillLongRightTriangle2(p1, p2, p3);
+                this.fillLongRightTriangle2(framebuffer, p1, p2, p3);
             } else {
                 const tex = p1.textureCoordinate;
                 const tex2 = p2.textureCoordinate;
                 const tex3 = p3.textureCoordinate;
 
                 this.fillLongLeftTriangle2(
+                    framebuffer,
                     p1.position,
                     p2.position,
                     p3.position,
@@ -55,7 +56,7 @@ export class TexturedTriangleRasterizer {
         }
     }
 
-    private fillLongRightTriangle2(v1: Vertex, v2: Vertex, v3: Vertex): void {
+    private fillLongRightTriangle2(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
         let yDistanceLeft = v2.position.y - v1.position.y;
 
 
@@ -89,7 +90,7 @@ export class TexturedTriangleRasterizer {
 
         for (let i = 0; i < yDistanceLeft; i++) {
             const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition)
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition)
             const spanzStep = (curz2 - curz1) / length;
             const spanuStep = (curu2 - curu1) / length;
             const spanvStep = (curv2 - curv1) / length;
@@ -98,15 +99,15 @@ export class TexturedTriangleRasterizer {
             let uStart = curu1;
             let vStart = curv1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
                     const z = 1 / wStart;
 
-                    const u = Math.max(Math.min((uStart * z * this.framebuffer.bob.width), this.framebuffer.bob.width - 1), 0) | 0;
-                    const v = Math.max(Math.min((vStart * z * this.framebuffer.bob.height), this.framebuffer.bob.height - 1), 0) | 0;
-                    const color2 = this.framebuffer.bob.texture[u + v * this.framebuffer.bob.width];
+                    const u = Math.max(Math.min((uStart * z * framebuffer.bob.width), framebuffer.bob.width - 1), 0) | 0;
+                    const v = Math.max(Math.min((vStart * z * framebuffer.bob.height), framebuffer.bob.height - 1), 0) | 0;
+                    const color2 = framebuffer.bob.texture[u + v * framebuffer.bob.width];
 
-                    this.framebuffer.framebuffer[framebufferIndex] = color2;
+                    framebuffer.framebuffer[framebufferIndex] = color2;
 
                 }
                 framebufferIndex++;
@@ -149,7 +150,7 @@ export class TexturedTriangleRasterizer {
 
         for (let i = 0; i < yDistanceLeft; i++) {
             const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition)
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition)
 
             const spanzStep = (curz2 - curz1) / length;
             const spanuStep = (curu2 - curu1) / length;
@@ -159,17 +160,17 @@ export class TexturedTriangleRasterizer {
             let uStart = curu1;
             let vStart = curv1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
 
                     const z = 1 / wStart;
 
 
-                    const u = Math.max(Math.min((uStart * z * this.framebuffer.bob.width), this.framebuffer.bob.width - 1), 0) | 0;
-                    const v = Math.max(Math.min((vStart * z * this.framebuffer.bob.height), this.framebuffer.bob.height - 1), 0) | 0;
-                    const color2 = this.framebuffer.bob.texture[u + v * this.framebuffer.bob.width];
+                    const u = Math.max(Math.min((uStart * z * framebuffer.bob.width), framebuffer.bob.width - 1), 0) | 0;
+                    const v = Math.max(Math.min((vStart * z * framebuffer.bob.height), framebuffer.bob.height - 1), 0) | 0;
+                    const color2 = framebuffer.bob.texture[u + v * framebuffer.bob.width];
 
-                    this.framebuffer.framebuffer[framebufferIndex] = color2;
+                    framebuffer.framebuffer[framebufferIndex] = color2;
                 }
                 framebufferIndex++;
                 wStart += spanzStep;
@@ -195,7 +196,7 @@ export class TexturedTriangleRasterizer {
     }
 
 
-    fillLongLeftTriangle2(v1: Vector4f, v2: Vector4f, v3: Vector4f, t1: Vector3f, t2: Vector3f, t3: Vector3f): void {
+    fillLongLeftTriangle2(framebuffer: Framebuffer, v1: Vector4f, v2: Vector4f, v3: Vector4f, t1: Vector3f, t2: Vector3f, t3: Vector3f): void {
 
         let yDistanceRight = v2.y - v1.y;
         const yDistanceLeft = v3.y - v1.y;
@@ -230,7 +231,7 @@ export class TexturedTriangleRasterizer {
 
         for (let i = 0; i < yDistanceRight; i++) {
             const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition)
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition)
             const spanzStep = (curz2 - curz1) / length;
             const spanuStep = (curu2 - curu1) / length;
             const spanvStep = (curv2 - curv1) / length;
@@ -239,16 +240,16 @@ export class TexturedTriangleRasterizer {
             let uStart = curu1;
             let vStart = curv1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
                     const z = 1 / wStart;
 
 
-                    const u = Math.max(Math.min((uStart * z * this.framebuffer.bob.width), this.framebuffer.bob.width - 1), 0) | 0;
-                    const v = Math.max(Math.min((vStart * z * this.framebuffer.bob.height), this.framebuffer.bob.height - 1), 0) | 0;
-                    const color2 = this.framebuffer.bob.texture[u + v * this.framebuffer.bob.width];
+                    const u = Math.max(Math.min((uStart * z * framebuffer.bob.width), framebuffer.bob.width - 1), 0) | 0;
+                    const v = Math.max(Math.min((vStart * z * framebuffer.bob.height), framebuffer.bob.height - 1), 0) | 0;
+                    const color2 = framebuffer.bob.texture[u + v * framebuffer.bob.width];
 
-                    this.framebuffer.framebuffer[framebufferIndex] = color2;
+                    framebuffer.framebuffer[framebufferIndex] = color2;
                 }
                 framebufferIndex++;
                 wStart += spanzStep;
@@ -291,7 +292,7 @@ export class TexturedTriangleRasterizer {
 
         for (let i = 0; i < yDistanceRight; i++) {
             const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition)
+            let framebufferIndex = Math.round(yPosition) * framebuffer.width + Math.round(xPosition)
 
 
             const spanzStep = (curz2 - curz1) / length;
@@ -302,15 +303,15 @@ export class TexturedTriangleRasterizer {
             let uStart = curu1;
             let vStart = curv1;
             for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
+                if (wStart < framebuffer.wBuffer[framebufferIndex]) {
+                    framebuffer.wBuffer[framebufferIndex] = wStart;
                     const z = 1 / wStart;
 
-                    const u = Math.max(Math.min((uStart * z * this.framebuffer.bob.width), this.framebuffer.bob.width - 1), 0) | 0;
-                    const v = Math.max(Math.min((vStart * z * this.framebuffer.bob.height), this.framebuffer.bob.height - 1), 0) | 0;
-                    const color2 = this.framebuffer.bob.texture[u + v * this.framebuffer.bob.width];
+                    const u = Math.max(Math.min((uStart * z * framebuffer.bob.width), framebuffer.bob.width - 1), 0) | 0;
+                    const v = Math.max(Math.min((vStart * z * framebuffer.bob.height), framebuffer.bob.height - 1), 0) | 0;
+                    const color2 = framebuffer.bob.texture[u + v * framebuffer.bob.width];
 
-                    this.framebuffer.framebuffer[framebufferIndex] = color2;
+                    framebuffer.framebuffer[framebufferIndex] = color2;
                 }
                 framebufferIndex++;
                 wStart += spanzStep;

--- a/src/rendering-pipelines/FlatShadingRenderingPipeline.ts
+++ b/src/rendering-pipelines/FlatShadingRenderingPipeline.ts
@@ -96,7 +96,7 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
         this.color = color;
     }
 
-    public draw(mesh: FlatshadedMesh, modelViewMartrix: Matrix4f): void {
+    public draw(framebuffer: Framebuffer, mesh: FlatshadedMesh, modelViewMartrix: Matrix4f): void {
 
         const normalMatrix: Matrix4f = modelViewMartrix.computeNormalMatrix();
 
@@ -137,7 +137,7 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
                 this.vertexArray[2].projection = this.projectedVertices[2];
                 this.vertexArray[2].normal = normal3;
 
-                this.renderConvexPolygon(this.vertexArray, true);
+                this.renderConvexPolygon(framebuffer, this.vertexArray, true);
             } else if (!this.isInFrontOfNearPlane(v1) &&
                 !this.isInFrontOfNearPlane(v2) &&
                 !this.isInFrontOfNearPlane(v3)) {
@@ -172,7 +172,7 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
                     output[j].projection = this.project(output[j].position);
                 }
 
-                this.renderConvexPolygon(output);
+                this.renderConvexPolygon(framebuffer, output, false);
             }
         }
     }
@@ -225,7 +225,7 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
         return output;
     }
 
-    private renderConvexPolygon(projected: Array<Vertex>, late: boolean = false): void {
+    private renderConvexPolygon(framebuffer: Framebuffer, projected: Array<Vertex>, late: boolean = false): void {
         if (projected.length === 3 &&
             !this.isTriangleCCW(
                 projected[0].projection,
@@ -263,12 +263,13 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
             return;
         }
 
-        this.triangulateConvexPolygon(clippedPolygon);
+        this.triangulateConvexPolygon(framebuffer, clippedPolygon);
     }
 
-    private triangulateConvexPolygon(clippedPolygon: Array<Vertex>): void {
+    private triangulateConvexPolygon(framebuffer:Framebuffer, clippedPolygon: Array<Vertex>): void {
         for (let j: number = 0; j < clippedPolygon.length - 2; j++) {
             this.triangleRasterizer.drawTriangleDDA(
+                framebuffer,
                 clippedPolygon[0],
                 clippedPolygon[1 + j],
                 clippedPolygon[2 + j]

--- a/src/rendering-pipelines/TexturingRenderingPipeline.ts
+++ b/src/rendering-pipelines/TexturingRenderingPipeline.ts
@@ -41,14 +41,14 @@ export class TexturingRenderingPipeline extends AbstractRenderingPipeline {
         this.modelViewMatrix = matrix;
     }
 
-    public drawMeshArray(meshes: Array<TexturedMesh>): void {
+    public drawMeshArray(framebuffer: Framebuffer, meshes: Array<TexturedMesh>): void {
         for (let j: number = 0; j < meshes.length; j++) {
             const model: TexturedMesh = meshes[j];
-            this.draw(model);
+            this.draw(framebuffer, model);
         }
     }
 
-    public draw(mesh: TexturedMesh): void {
+    public draw(framebuffer: Framebuffer, mesh: TexturedMesh): void {
 
         for (let i: number = 0; i < mesh.points.length; i++) {
             this.modelViewMatrix.multiplyHomArr(mesh.points[i], mesh.points2[i]);
@@ -81,7 +81,7 @@ export class TexturingRenderingPipeline extends AbstractRenderingPipeline {
                     this.vertexArray[2].position = this.projectedVertices[2];
                     this.vertexArray[2].textureCoordinate = mesh.uv[mesh.faces[i].uv[2]];
 
-                    this.clipConvexPolygon2(this.vertexArray);
+                    this.clipConvexPolygon2(framebuffer, this.vertexArray);
                 }
             } else if (!this.isInFrontOfNearPlane(v1) &&
                 !this.isInFrontOfNearPlane(v2) &&
@@ -97,7 +97,7 @@ export class TexturingRenderingPipeline extends AbstractRenderingPipeline {
                 this.vertexArray[2].position = v3;
                 this.vertexArray[2].textureCoordinate = mesh.uv[mesh.faces[i].uv[2]];
 
-                this.zClipTriangle2(this.vertexArray);
+                this.zClipTriangle2(framebuffer, this.vertexArray);
             }
         }
     }
@@ -134,7 +134,7 @@ export class TexturingRenderingPipeline extends AbstractRenderingPipeline {
         return vertex;
     }
 
-    public zClipTriangle2(subject: Array<Vertex>): void {
+    public zClipTriangle2(framebuffer: Framebuffer, subject: Array<Vertex>): void {
         const input: Array<Vertex> = subject;
         const output: Array<Vertex> = new Array<Vertex>();
         let S: Vertex = input[input.length - 1];
@@ -177,11 +177,11 @@ export class TexturingRenderingPipeline extends AbstractRenderingPipeline {
             return;
         }
 
-        this.clipConvexPolygon2(projected);
+        this.clipConvexPolygon2(framebuffer, projected);
     }
 
 
-    public clipConvexPolygon2(subject: Array<Vertex>): void {
+    public clipConvexPolygon2(framebuffer: Framebuffer, subject: Array<Vertex>): void {
 
         let output = subject;
 
@@ -211,7 +211,7 @@ export class TexturingRenderingPipeline extends AbstractRenderingPipeline {
 
         // triangulate new point set
         for (let i = 0; i < output.length - 2; i++) {
-            this.triangleRasterizer.drawTriangleDDA(output[0], output[1 + i], output[2 + i]);
+            this.triangleRasterizer.drawTriangleDDA(framebuffer, output[0], output[1 + i], output[2 + i]);
         }
     }
 


### PR DESCRIPTION
+6 FPS when using transitions with less spikey spikes. I tested all standalone examples working as they did before.  Depending the size of your CPU L1/L2 cache, you may or may not see the performance dip. I have a i5-3470 CPU released in 2012.

**performance before:**
![blip](https://user-images.githubusercontent.com/2692017/106776668-494a9080-6612-11eb-9f94-d207c5e3a0c4.jpg)

**performance after:**
![blip_after](https://user-images.githubusercontent.com/2692017/106776683-4ea7db00-6612-11eb-92ad-d3103c374b57.jpg)


**RenderingPipeLine, TriangleRasterizers, FontRenderer**
 - Render into target framebuffer vs always rendering into framebuffer initialized during init(). This was needed to avoid copy step during transitions and to allow greater flexibility when combining multiple scenes.

**BlockFade.ts** 
-  avoid expensive copy to temp texture line
 - optimized 2 for loops into 1
 - reduced clamping
 - tested all transition types

**DistoredSphereScene** 
- removed some multiplication

**TorusKnotScene, TorusKnowTunnelScene**
- extend glitch effect to entire screen if we choose to change the resolution to 360x200

**everything else mostly changes:**

from:
this.renderingPipeline.draw(model, mv);

to:
this.renderingPipeline.draw(framebuffer, model, mv);
