### PR TITLE
feature: add experimental subpixel rendering pipeline & separate flat and gouraud pipelines

### DIFF
--- a/src/Framebuffer.ts
+++ b/src/Framebuffer.ts
@@ -160,6 +160,52 @@ export class Framebuffer {
 
     }
 
+    /**
+     * Renders a pixel using fractional x,y coordinates
+     * blended with the framebuffer background
+     *
+     * @param  {x} number                 this can be a float
+     * @param  {y} number                 this can be a float
+     * @param  {color} number             color to blend into framebuffer
+     */
+    drawPixelAntiAliased(x: number, y: number, color: number) {
+        if ((x < 0 || x >= this.width) || (y < 0 || y >= this.height)) return;
+        const roundedX = Math.floor(x);
+        const roundedY = Math.floor(y);
+        const percentX = 1 - Math.abs(x - roundedX);
+        const percentY = 1 - Math.abs(y - roundedY);
+        const percent = percentX * percentY;
+        this.drawPixel3(roundedX, roundedY, color, percent);
+    }
+
+    /**
+     * Renders a pixel using fractional x,y coordinates
+     * to the framebuffer background
+     */
+    drawPixelAliased(x: number, y: number, color: number) {
+        if ((x < 0 || x >= this.width) || (y < 0 || y >= this.height)) return;
+        const roundedX = Math.round(x);
+        const roundedY = Math.round(y)
+        this.drawPixel(roundedX, roundedY, color);
+    }
+
+    /**
+     * Renders a pixel using fractional x,y coordinates
+     * blended with the framebuffer background in a 4x4 matrix
+     * https://en.wikipedia.org/wiki/Spatial_anti-aliasing
+     */
+    drawPixelAntiAliasedSpacial(x: number, y: number, color: number) {
+        if ((x < 0 || x >= this.width) || (y < 0 || y >= this.height)) return;
+        for (let roundedX = Math.floor(x); roundedX <= Math.ceil(x); roundedX++) {
+            for (let roundedY = Math.floor(y); roundedY <= Math.ceil(y); roundedY++) {
+                const percentX = 1 - Math.abs(x - roundedX);
+                const percentY = 1 - Math.abs(y - roundedY);
+                const percent = percentX * percentY;
+                this.drawPixel4(roundedX, roundedY, color, percent);
+            }
+        }
+    }
+
     public readPixel(x: number, y: number): number {
         return this.framebuffer[x + y * this.width];
     }
@@ -286,7 +332,8 @@ export class Framebuffer {
      *
      * @param  {number} c1
      * @param  {number} c2
-     * @return {number}     difference between c1 and c2 from 0-255
+     * @param  {number} alpha number ranging from 0-255
+     * @return {number}     color blended difference between c1 and c2
      */
     public static blend(c1: number, c2: number, nAlpha: number): number {
 

--- a/src/examples/abstract-cube/AbstractCube.ts
+++ b/src/examples/abstract-cube/AbstractCube.ts
@@ -2,7 +2,7 @@ import { CullFace } from '../../CullFace';
 import { Framebuffer } from '../../Framebuffer';
 import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
 import { Matrix4f } from '../../math/Matrix4f';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
@@ -17,13 +17,13 @@ export class AbstractCube extends AbstractScene {
     private noise: Texture;
 
     private accumulationBuffer: Uint32Array;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     private scene: Array<FlatshadedMesh>;
 
     public init(framebuffer: Framebuffer): Promise<any> {
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
 
         return Promise.all([

--- a/src/examples/blender-camera-animation/WavefrontScene.ts
+++ b/src/examples/blender-camera-animation/WavefrontScene.ts
@@ -15,7 +15,7 @@ import { ModelViewMatrix } from '../md2/ModelViewMatrix';
 import CameraPathFile from '../../assets/camera-path.jsx';
 import { BlenderCameraAnimator } from '../../animation/BlenderCameraAnimator';
 import { SkyBox } from '../../SkyBox';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 export class BlenderCameraScene extends AbstractScene {
 
@@ -37,10 +37,10 @@ export class BlenderCameraScene extends AbstractScene {
     private light1: PointLight;
     private light2: PointLight;
 
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
 
         this.light1 = new PointLight();

--- a/src/examples/bunny/BunnyScene.ts
+++ b/src/examples/bunny/BunnyScene.ts
@@ -4,7 +4,7 @@ import { Framebuffer } from '../../Framebuffer';
 import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
 import { Vector4f } from '../../math';
 import { Matrix4f } from '../../math/Matrix4f';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { PointLight } from '../../shading/light/PointLight';
 import { Material } from '../../shading/material/Material';
@@ -19,11 +19,11 @@ export class BunnyScene extends AbstractScene {
 
     private blurred: Texture;
     private noise: Texture;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
     private scene: Array<FlatshadedMesh>;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
         this.renderingPipeline.setLights(this.constructSceneLights());
         this.renderingPipeline.setMaterial(this.constructSceneMaterial());

--- a/src/examples/cube-subpixel/Application.ts
+++ b/src/examples/cube-subpixel/Application.ts
@@ -1,0 +1,13 @@
+import { Canvas } from '../../Canvas';
+import { SubPixelCubeScene } from './SubPixelCubeScene';
+
+class Application {
+
+    public static main(): void {
+        const canvas: Canvas = new Canvas(320, 200, new SubPixelCubeScene());
+        canvas.init();
+    }
+
+}
+
+Application.main();

--- a/src/examples/cube-subpixel/SubPixelCubeScene.ts
+++ b/src/examples/cube-subpixel/SubPixelCubeScene.ts
@@ -1,0 +1,55 @@
+import { Color } from '../../core/Color';
+import { CullFace } from '../../CullFace';
+import { Framebuffer } from '../../Framebuffer';
+import { Cube } from '../../geometrical-objects/Cube';
+import { Matrix4f } from '../../math';
+import { SubPixelRenderingPipeline } from '../../rendering-pipelines/SubPixelRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
+import { AbstractScene } from '../../scenes/AbstractScene';
+
+export class SubPixelCubeScene extends AbstractScene {
+
+    private static BACKGROUND_COLOR: number = Color.BLACK.toPackedFormat();
+    private subPixelRenderingPipeline: SubPixelRenderingPipeline;
+    private gouraudRenderingPipeline: GouraudShadingRenderingPipeline;
+    private cubeMesh: Cube = new Cube();
+
+    public init(framebuffer: Framebuffer): Promise<any> {
+
+        return Promise.all([
+            this.subPixelRenderingPipeline = new SubPixelRenderingPipeline(framebuffer),
+            this.subPixelRenderingPipeline.setCullFace(CullFace.BACK),
+
+            this.gouraudRenderingPipeline = new GouraudShadingRenderingPipeline(framebuffer),
+            this.gouraudRenderingPipeline.setCullFace(CullFace.BACK),
+        ]);
+
+    }
+
+    public render(framebuffer: Framebuffer, time: number): void {
+        // rotate slowly to showcase
+        const elapsedTime: number = time * 0.001;
+        framebuffer.clearColorBuffer(SubPixelCubeScene.BACKGROUND_COLOR);
+        framebuffer.clearDepthBuffer();
+
+        // compare subpixel to gourad
+        this.subPixelRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,-3));
+        this.gouraudRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,3));
+    }
+
+    public renderBackground(framebuffer: Framebuffer, time: number): void {
+        const elapsedTime: number = time * 0.02;
+        framebuffer.clearDepthBuffer();
+        this.subPixelRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,5));
+    }
+
+    private getModelViewMatrix(elapsedTime: number, xShift: number): Matrix4f {
+        const scale: number = 3.2;
+
+        return Matrix4f.constructTranslationMatrix(xShift, 0, -12).multiplyMatrix(
+            Matrix4f.constructScaleMatrix(scale, scale, scale).multiplyMatrix(
+                Matrix4f.constructYRotationMatrix(elapsedTime * 0.05)).multiplyMatrix(
+                    Matrix4f.constructXRotationMatrix(elapsedTime * 0.08)));
+    }
+
+}

--- a/src/examples/cube-tunnel/CubeTunnelScene.ts
+++ b/src/examples/cube-tunnel/CubeTunnelScene.ts
@@ -4,7 +4,7 @@ import { Framebuffer } from '../../Framebuffer';
 import { Cube } from '../../geometrical-objects/Cube';
 import { Matrix4f } from '../../math/Matrix4f';
 import RandomNumberGenerator from '../../RandomNumberGenerator';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture, TextureUtils } from '../../texture/index';
 import { Vector4f } from '../../math';
@@ -17,14 +17,14 @@ import { PointLight } from '../../shading/light/PointLight';
 export class CubeTunnelScene extends AbstractScene {
 
     private static BACKGROUND_COLOR: number = Color.DARK_GRAY.toPackedFormat();
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
     private cubeMesh: Cube = new Cube();
     private accumulationBuffer: Uint32Array;
 
     public init(framebuffer: Framebuffer): Promise<any> {
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
         framebuffer.setCullFace(CullFace.BACK);
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
 
         const light1: PointLight = new PointLight();
         light1.ambientIntensity = new Vector4f(1, 1, 1, 1);

--- a/src/examples/cube/CubeScene.ts
+++ b/src/examples/cube/CubeScene.ts
@@ -4,38 +4,46 @@ import { Framebuffer } from '../../Framebuffer';
 import { Cube } from '../../geometrical-objects/Cube';
 import { Matrix4f } from '../../math';
 import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 
 export class CubeScene extends AbstractScene {
 
     private static BACKGROUND_COLOR: number = Color.BLACK.toPackedFormat();
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private flatRenderingPipeline: FlatShadingRenderingPipeline;
+    private gouraudRenderingPipeline: GouraudShadingRenderingPipeline;
     private cubeMesh: Cube = new Cube();
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
-        this.renderingPipeline.setCullFace(CullFace.BACK);
 
-        return Promise.all([]);
+        return Promise.all([
+            this.flatRenderingPipeline = new FlatShadingRenderingPipeline(framebuffer),
+            this.flatRenderingPipeline.setCullFace(CullFace.BACK),
+
+            this.gouraudRenderingPipeline = new GouraudShadingRenderingPipeline(framebuffer),
+            this.gouraudRenderingPipeline.setCullFace(CullFace.BACK),
+        ]);
+
     }
 
     public render(framebuffer: Framebuffer, time: number): void {
-        const elapsedTime: number = time * 0.02;
+        const elapsedTime: number = time * 0.001;
         framebuffer.clearColorBuffer(CubeScene.BACKGROUND_COLOR);
         framebuffer.clearDepthBuffer();
-        this.renderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime));
+        this.flatRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,-3));
+        this.gouraudRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,3));
     }
 
     public renderBackground(framebuffer: Framebuffer, time: number): void {
         const elapsedTime: number = time * 0.02;
         framebuffer.clearDepthBuffer();
-        this.renderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime));
+        this.flatRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,5));
     }
 
-    private getModelViewMatrix(elapsedTime: number): Matrix4f {
+    private getModelViewMatrix(elapsedTime: number, xShift: number): Matrix4f {
         const scale: number = 3.2;
 
-        return Matrix4f.constructTranslationMatrix(0, 0, -9).multiplyMatrix(
+        return Matrix4f.constructTranslationMatrix(xShift, 0, -12).multiplyMatrix(
             Matrix4f.constructScaleMatrix(scale, scale, scale).multiplyMatrix(
                 Matrix4f.constructYRotationMatrix(elapsedTime * 0.05)).multiplyMatrix(
                     Matrix4f.constructXRotationMatrix(elapsedTime * 0.08)));

--- a/src/examples/cube/CubeScene.ts
+++ b/src/examples/cube/CubeScene.ts
@@ -3,17 +3,17 @@ import { CullFace } from '../../CullFace';
 import { Framebuffer } from '../../Framebuffer';
 import { Cube } from '../../geometrical-objects/Cube';
 import { Matrix4f } from '../../math';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 
 export class CubeScene extends AbstractScene {
 
     private static BACKGROUND_COLOR: number = Color.BLACK.toPackedFormat();
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
     private cubeMesh: Cube = new Cube();
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
 
         return Promise.all([]);

--- a/src/examples/cube/CubeScene.ts
+++ b/src/examples/cube/CubeScene.ts
@@ -4,46 +4,38 @@ import { Framebuffer } from '../../Framebuffer';
 import { Cube } from '../../geometrical-objects/Cube';
 import { Matrix4f } from '../../math';
 import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
-import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 
 export class CubeScene extends AbstractScene {
 
     private static BACKGROUND_COLOR: number = Color.BLACK.toPackedFormat();
-    private flatRenderingPipeline: FlatShadingRenderingPipeline;
-    private gouraudRenderingPipeline: GouraudShadingRenderingPipeline;
+    private renderingPipeline: FlatShadingRenderingPipeline;
     private cubeMesh: Cube = new Cube();
 
     public init(framebuffer: Framebuffer): Promise<any> {
+        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline.setCullFace(CullFace.BACK);
 
-        return Promise.all([
-            this.flatRenderingPipeline = new FlatShadingRenderingPipeline(framebuffer),
-            this.flatRenderingPipeline.setCullFace(CullFace.BACK),
-
-            this.gouraudRenderingPipeline = new GouraudShadingRenderingPipeline(framebuffer),
-            this.gouraudRenderingPipeline.setCullFace(CullFace.BACK),
-        ]);
-
+        return Promise.all([]);
     }
 
     public render(framebuffer: Framebuffer, time: number): void {
-        const elapsedTime: number = time * 0.001;
+        const elapsedTime: number = time * 0.02;
         framebuffer.clearColorBuffer(CubeScene.BACKGROUND_COLOR);
         framebuffer.clearDepthBuffer();
-        this.flatRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,-3));
-        this.gouraudRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,3));
+        this.renderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime));
     }
 
     public renderBackground(framebuffer: Framebuffer, time: number): void {
         const elapsedTime: number = time * 0.02;
         framebuffer.clearDepthBuffer();
-        this.flatRenderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime,5));
+        this.renderingPipeline.draw(framebuffer, this.cubeMesh.getMesh(), this.getModelViewMatrix(elapsedTime));
     }
 
-    private getModelViewMatrix(elapsedTime: number, xShift: number): Matrix4f {
+    private getModelViewMatrix(elapsedTime: number): Matrix4f {
         const scale: number = 3.2;
 
-        return Matrix4f.constructTranslationMatrix(xShift, 0, -12).multiplyMatrix(
+        return Matrix4f.constructTranslationMatrix(0, 0, -9).multiplyMatrix(
             Matrix4f.constructScaleMatrix(scale, scale, scale).multiplyMatrix(
                 Matrix4f.constructYRotationMatrix(elapsedTime * 0.05)).multiplyMatrix(
                     Matrix4f.constructXRotationMatrix(elapsedTime * 0.08)));

--- a/src/examples/demo/parts/Scene9.ts
+++ b/src/examples/demo/parts/Scene9.ts
@@ -1,5 +1,5 @@
 import { Framebuffer } from '../../../Framebuffer';
-import { FlatShadingRenderingPipeline } from '../../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { BlenderCameraScene } from '../../blender-camera-animation/WavefrontScene';
 
 

--- a/src/examples/frustum-culling/FrustumCullingScene.ts
+++ b/src/examples/frustum-culling/FrustumCullingScene.ts
@@ -9,7 +9,7 @@ import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
 import { Matrix4f, Vector3f } from '../../math';
 import { Sphere } from '../../math/Sphere';
 import RandomNumberGenerator from '../../RandomNumberGenerator';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture } from '../../texture';
 import { BlenderLoader } from '../../model/blender/BlenderLoader';
@@ -18,10 +18,10 @@ export class FrustumCullingScene extends AbstractScene {
 
     private world: Array<[FlatshadedMesh, Sphere]>;
 
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
 
         return Promise.all([

--- a/src/examples/gears-2/Gears2Scene.ts
+++ b/src/examples/gears-2/Gears2Scene.ts
@@ -2,7 +2,7 @@ import { CullFace } from '../../CullFace';
 import { Framebuffer } from '../../Framebuffer';
 import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
 import { Matrix4f } from '../../math/Matrix4f';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
@@ -24,11 +24,11 @@ export class Gears2Scene extends AbstractScene {
     private gearsMesh: Array<FlatshadedMesh>;
 
     private accumulationBuffer: Uint32Array;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.FRONT);
 
         return Promise.all([

--- a/src/examples/gears/GearsScene.ts
+++ b/src/examples/gears/GearsScene.ts
@@ -2,7 +2,7 @@ import { CullFace } from '../../CullFace';
 import { Framebuffer } from '../../Framebuffer';
 import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
 import { Matrix4f } from '../../math/Matrix4f';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
@@ -15,11 +15,11 @@ export class GearsScene extends AbstractScene {
     private gearsMesh: Array<FlatshadedMesh>;
 
     private accumulationBuffer: Uint32Array;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.FRONT);
 
         return Promise.all([

--- a/src/examples/hoodlum/HoodlumScene.ts
+++ b/src/examples/hoodlum/HoodlumScene.ts
@@ -8,7 +8,7 @@ import { Texture, TextureUtils } from '../../texture';
 import { BlenderLoader } from './../../model/blender/BlenderLoader';
 import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
 import { TexturingRenderingPipeline } from '../../rendering-pipelines/TexturingRenderingPipeline';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 export class HoodlumScene extends AbstractScene {
 
@@ -21,11 +21,11 @@ export class HoodlumScene extends AbstractScene {
     private accumulationBuffer: Uint32Array;
 
     private texturedRenderingPipeline: TexturingRenderingPipeline;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
         this.texturedRenderingPipeline = new TexturingRenderingPipeline(framebuffer);
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
         return Promise.all([
             TextureUtils.load(require('../../assets/blurredBackground.png'), false).then(

--- a/src/examples/mdl/Md2ModelScene.ts
+++ b/src/examples/mdl/Md2ModelScene.ts
@@ -11,7 +11,7 @@ import { WavefrontLoader } from '../../model/wavefront-obj/WavefrontLoader';
 import { ThirdPersonCamera } from '../../camera/ThirdPersonCamera';
 import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
 import { TexturingRenderingPipeline } from '../../rendering-pipelines/TexturingRenderingPipeline';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 /**
  * http://tfc.duke.free.fr/coding/mdl-specs-en.html
@@ -35,10 +35,10 @@ export class Md2ModelScene extends AbstractScene {
     private fps: number = 0;
 
     private meshes: Array<FlatshadedMesh>;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
         this.startTime = Date.now();
         return Promise.all([

--- a/src/examples/moving-torus/MovingTorusScene.ts
+++ b/src/examples/moving-torus/MovingTorusScene.ts
@@ -4,16 +4,16 @@ import { Torus } from '../../geometrical-objects/Torus';
 import { Matrix4f } from '../../math/index';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture, TextureUtils } from '../../texture/index';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 export class MovingTorusScene extends AbstractScene {
 
     private background: Texture;
     private torus: Torus = new Torus();
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         framebuffer.setCullFace(CullFace.BACK);
 
         return Promise.all([

--- a/src/examples/razor/RazorScene.ts
+++ b/src/examples/razor/RazorScene.ts
@@ -8,7 +8,7 @@ import { Matrix4f, Vector3f } from '../../math';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture, TextureUtils } from '../../texture';
 import { Color } from '../../core/Color';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 /**
  * TODO: extract lens into effect class
@@ -27,10 +27,10 @@ export class RazorScene extends AbstractScene {
     private icosahedron: Sphere; // Icosahedron;
 
     private accumulationBuffer: Uint32Array;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
         this.renderingPipeline.setCullFace(CullFace.BACK);
 

--- a/src/examples/room/RoomScene.ts
+++ b/src/examples/room/RoomScene.ts
@@ -5,7 +5,7 @@ import { Texture, TextureUtils } from '../../texture';
 import { Material } from '../../shading/material/Material';
 import { BlenderLoader } from './../../model/blender/BlenderLoader';
 import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 export class RoomScene extends AbstractScene {
 
@@ -17,10 +17,10 @@ export class RoomScene extends AbstractScene {
     private dirt: Texture;
     private blenderObj4: Array<FlatshadedMesh>;
     private blenderObj5: Array<FlatshadedMesh>;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setFramebuffer(framebuffer);
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
 

--- a/src/examples/rotating-gears/RotatingGearsScene.ts
+++ b/src/examples/rotating-gears/RotatingGearsScene.ts
@@ -2,7 +2,7 @@ import { CullFace } from '../../CullFace';
 import { Framebuffer } from '../../Framebuffer';
 import { FlatshadedMesh } from '../../geometrical-objects/FlatshadedMesh';
 import { Matrix4f } from '../../math';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture, TextureUtils } from '../../texture';
 import { BlenderLoader } from '../../model/blender/BlenderLoader';
@@ -16,11 +16,11 @@ export class RotatingGearsScene extends AbstractScene {
     private gearsMesh: Array<FlatshadedMesh>;
 
     private accumulationBuffer: Uint32Array;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.FRONT);
 
         return Promise.all([

--- a/src/examples/torus-knot-tunnel/TorusKnotTunnelScene.ts
+++ b/src/examples/torus-knot-tunnel/TorusKnotTunnelScene.ts
@@ -10,7 +10,7 @@ import { LinearFog } from '../../shading/fog/LinearFog';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
 import RandomNumberGenerator from '../../RandomNumberGenerator';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 export class TorusKnotTunnelScene extends AbstractScene {
 
@@ -19,10 +19,10 @@ export class TorusKnotTunnelScene extends AbstractScene {
     private cocoon: Texture;
     private torusKnot: TorusKnot = new TorusKnot(true);
     private fog: Fog = new LinearFog(-50, -240, new Vector4f(0.67, 0.4, 0.5, 1.0));
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.FRONT);
         this.renderingPipeline.setFog(this.fog);
 

--- a/src/examples/torus-knot/TorusKnotScene.ts
+++ b/src/examples/torus-knot/TorusKnotScene.ts
@@ -8,7 +8,7 @@ import { AbstractScene } from '../../scenes/AbstractScene';
 import { LinearFog } from '../../shading/fog/LinearFog';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 export class TorusKnotScene extends AbstractScene {
 
@@ -17,10 +17,10 @@ export class TorusKnotScene extends AbstractScene {
     private noise: Texture;
     private micro: Texture;
     private startTime: number;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
         this.renderingPipeline.setFog(new LinearFog(-160, -380, new Vector4f(0, 0, 0, 1)));
         this.startTime = Date.now();

--- a/src/examples/torus/TorusScene.ts
+++ b/src/examples/torus/TorusScene.ts
@@ -6,6 +6,7 @@ import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
 import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { Color } from '../../core/Color';
 
 export class TorusScene extends AbstractScene {
 
@@ -25,10 +26,12 @@ export class TorusScene extends AbstractScene {
     }
 
     public render(framebuffer: Framebuffer, time: number): void {
+        framebuffer.clearColorBuffer(Color.BLACK.toPackedFormat());
 
-        this.drawTitanEffect(framebuffer, time);
-        this.shadingTorus(framebuffer, time * 0.02);
-        framebuffer.drawTexture(framebuffer.width / 2 - this.razorLogo.width / 2, 0, this.razorLogo, 1.0);
+
+        // this.drawTitanEffect(framebuffer, time);
+        this.shadingTorus(framebuffer, time * 0.0003);
+        // framebuffer.drawTexture(framebuffer.width / 2 - this.razorLogo.width / 2, 0, this.razorLogo, 1.0);
     }
 
     public shadingTorus(framebuffer: Framebuffer, elapsedTime: number): void {

--- a/src/examples/torus/TorusScene.ts
+++ b/src/examples/torus/TorusScene.ts
@@ -6,7 +6,6 @@ import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
 import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
-import { Color } from '../../core/Color';
 
 export class TorusScene extends AbstractScene {
 
@@ -26,12 +25,10 @@ export class TorusScene extends AbstractScene {
     }
 
     public render(framebuffer: Framebuffer, time: number): void {
-        framebuffer.clearColorBuffer(Color.BLACK.toPackedFormat());
 
-
-        // this.drawTitanEffect(framebuffer, time);
-        this.shadingTorus(framebuffer, time * 0.0003);
-        // framebuffer.drawTexture(framebuffer.width / 2 - this.razorLogo.width / 2, 0, this.razorLogo, 1.0);
+        this.drawTitanEffect(framebuffer, time);
+        this.shadingTorus(framebuffer, time * 0.02);
+        framebuffer.drawTexture(framebuffer.width / 2 - this.razorLogo.width / 2, 0, this.razorLogo, 1.0);
     }
 
     public shadingTorus(framebuffer: Framebuffer, elapsedTime: number): void {

--- a/src/examples/torus/TorusScene.ts
+++ b/src/examples/torus/TorusScene.ts
@@ -5,16 +5,16 @@ import { Matrix4f } from '../../math/Matrix4f';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 export class TorusScene extends AbstractScene {
 
     private razorLogo: Texture;
     private torus: Torus = new Torus();
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
 
         return Promise.all([

--- a/src/examples/voxel-balls/VoxelBallsScene.ts
+++ b/src/examples/voxel-balls/VoxelBallsScene.ts
@@ -3,7 +3,7 @@ import { CullFace } from '../../CullFace';
 import { Framebuffer } from '../../Framebuffer';
 import { Cube } from '../../geometrical-objects/Cube';
 import { Matrix4f } from '../../math';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 import { AbstractScene } from '../../scenes/AbstractScene';
 import { TextureUtils, Texture } from '../../texture/index';
 
@@ -13,7 +13,7 @@ import { TextureUtils, Texture } from '../../texture/index';
 export class VoxelBallsScene extends AbstractScene {
 
     private static BACKGROUND_COLOR: number = Color.YELLOW.toPackedFormat();
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
     private cubeMesh: Cube = new Cube();
     private blurred: Texture;
     private accumulationBuffer: Uint32Array;
@@ -21,7 +21,7 @@ export class VoxelBallsScene extends AbstractScene {
     public init(framebuffer: Framebuffer): Promise<any> {
         this.accumulationBuffer = new Uint32Array(framebuffer.width * framebuffer.height);
         framebuffer.setCullFace(CullFace.BACK);
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         return Promise.all([
             TextureUtils.load(require('../../assets/blurredBackground.png'), false).then(
                 (texture: Texture) => this.blurred = texture

--- a/src/examples/wavefront/WavefrontScene.ts
+++ b/src/examples/wavefront/WavefrontScene.ts
@@ -9,7 +9,7 @@ import { PointLight } from '../../shading/light/PointLight';
 import { Texture } from '../../texture/Texture';
 import { TextureUtils } from '../../texture/TextureUtils';
 import { ModelViewMatrix } from '../md2/ModelViewMatrix';
-import { FlatShadingRenderingPipeline } from '../../rendering-pipelines/FlatShadingRenderingPipeline';
+import { GouraudShadingRenderingPipeline } from '../../rendering-pipelines/GouraudShadingRenderingPipeline';
 
 export class WavefrontScene extends AbstractScene {
 
@@ -25,10 +25,10 @@ export class WavefrontScene extends AbstractScene {
     private fps: number = 0;
 
     private meshes: Array<FlatshadedMesh>;
-    private renderingPipeline: FlatShadingRenderingPipeline;
+    private renderingPipeline: GouraudShadingRenderingPipeline;
 
     public init(framebuffer: Framebuffer): Promise<any> {
-        this.renderingPipeline = new FlatShadingRenderingPipeline(framebuffer);
+        this.renderingPipeline = new GouraudShadingRenderingPipeline(framebuffer);
         this.renderingPipeline.setCullFace(CullFace.BACK);
         this.renderingPipeline.setFramebuffer(framebuffer);
 

--- a/src/rasterizer/FlatShadingTriangleRasterizer.ts
+++ b/src/rasterizer/FlatShadingTriangleRasterizer.ts
@@ -1,6 +1,3 @@
-import { debug } from 'console';
-import { Color } from '../core/Color';
-import { Utils } from '../core/Utils';
 import { Framebuffer } from '../Framebuffer';
 import { Vertex } from '../Vertex';
 import { AbstractTriangleRasterizer } from './AbstractTriangleRasterizer';
@@ -18,132 +15,15 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
     private xPosition2: number;
     private yPosition: number;
 
-    // create depth buffer
-    // use Uint16 because we only need a little precision and we save 2 bytes per pixel this way
-    private depthBuffer;
-
     constructor(private framebuffer: Framebuffer) {
         super();
-        this.depthBuffer = new Uint16Array(this.framebuffer.width * this.framebuffer.height)
-        // add some properties and methods to make using this easier
-        this.depthBuffer.width = this.framebuffer.width;
-        this.depthBuffer.height = this.framebuffer.height;
-        this.depthBuffer.clear = function () { this.fill(65535); };
-        this.depthBuffer.getDepth = function (x, y) { return this[y * this.width + x] / 65535.0; };
-        this.depthBuffer.setDepth = function (x, y, v) { this[y * this.width + x] = (v * 65535) | 0; };
-        this.depthBuffer.testDepth = function (x, y, v) {
-            const value = (v * 65535) | 0;
-            if (value < 0 || value > 65535) {
-                return false;
-            }
-            const index = y * this.width + x;
-            if (value < this[index]) {
-                this[index] = value;
-                return true;
-            }
-            return false;
-        };
-        this.depthBuffer.clear();
-    }
-
-    // returns true if vertices are in counterclockwise order
-    isCcw(v0, v1, v2) {
-        return (v1.x - v0.x) * (v2.y - v0.y) - (v1.y - v0.y) * (v2.x - v0.x) >= 0;
-    }
-
-    cross(a, b, c) {
-        return (b.x - a.x) * -(c.y - a.y) - -(b.y - a.y) * (c.x - a.x);
-    }
-
-    // https://kitsunegames.com/assets/software-3d-rendering-in-javascript-pt2/result/
-    public fillTriangle(v0: Vertex, v1: Vertex, v2: Vertex) {
-
-        if (this.isCcw(v0.projection, v1.projection, v2.projection)) {
-            return;
-        }
-
-        const minX = Math.floor(Math.min(v0.projection.x, v1.projection.x, v2.projection.x));
-        const maxX = Math.ceil(Math.max(v0.projection.x, v1.projection.x, v2.projection.x));
-        const minY = Math.floor(Math.min(v0.projection.y, v1.projection.y, v2.projection.y));
-        const maxY = Math.ceil(Math.max(v0.projection.y, v1.projection.y, v2.projection.y));
-
-        // precalculate the area of the parallelogram defined by our triangle
-        const area = this.cross(v0.projection, v1.projection, v2.projection);
-
-        // calculate edges
-        const edge0 = { x: v2.projection.x - v1.projection.x, y: v2.projection.y - v1.projection.y };
-        const edge1 = { x: v0.projection.x - v2.projection.x, y: v0.projection.y - v2.projection.y };
-        const edge2 = { x: v1.projection.x - v0.projection.x, y: v1.projection.y - v0.projection.y };
-
-        // calculate which edges are right edges so we can easily skip them
-        // right edges go up, or (bottom edges) are horizontal edges that go right
-        const edgeRight0 = edge0.y < 0 || (edge0.y === 0 && edge0.x > 0);
-        const edgeRight1 = edge1.y < 0 || (edge1.y === 0 && edge0.x > 0);
-        const edgeRight2 = edge2.y < 0 || (edge2.y === 0 && edge0.x > 0);
-
-        // p is our 2D pixel location point
-        const p = { x: null, y: null };
-
-        // fragment is the resulting pixel with all the vertex attributes interpolated
-        const fragment = {
-            r: undefined,
-            g: undefined,
-            b: undefined,
-            a: undefined,
-            z: 0
-        };
-
-        for (let y = minY; y < maxY; y += .5) {
-            for (let x = minX; x < maxX; x += .5) {
-                // sample from the center of the pixel, not the top-left corner
-                p.x = x + 0.5; p.y = y + .5;
-
-                // calculate vertex weights
-                // should divide these by area, but we do that later
-                // so we divide once, not three times
-                const w0 = this.cross(v1.projection, v2.projection, p);
-                const w1 = this.cross(v2.projection, v0.projection, p);
-                const w2 = this.cross(v0.projection, v1.projection, p);
-
-                // if the point is not inside our polygon, skip fragment
-                if (w0 < 0 || w1 < 0 || w2 < 0) {
-                    continue;
-                }
-
-                // if this is a right or bottom edge, skip fragment (top-left rule):
-                if ((w0 === 0 && edgeRight0) || (w1 === 0 && edgeRight1) || (w2 === 0 && edgeRight2)) {
-                    continue;
-                }
-
-                // interpolate our vertices
-                fragment.r = (w0 * v0.color.r + w1 * v1.color.r + w2 * v2.color.r) / area;
-                fragment.g = (w0 * v0.color.g + w1 * v1.color.g + w2 * v2.color.g) / area;
-                fragment.b = (w0 * v0.color.b + w1 * v1.color.b + w2 * v2.color.b) / area;
-                fragment.a = (w0 * v0.projection.x + w1 * v1.projection.x + w2 * v2.projection.x) / area;
-                fragment.z = (w0 * v0.projection.z + w1 * v1.projection.z + w2 * v2.projection.z) / area;
-
-                let fragColor = new Color(
-                    fragment.r, fragment.g, fragment.b, fragment.a
-                )
-
-                // this can be optimized to only draw aliased pixels on the edges
-
-                //if (this.depthBuffer.testDepth(p.x, p.y, fragment.z)) {
-
-
-                this.framebuffer.drawPixelAntiAliasedSpacial(x, y, fragColor.toPackedFormat());
-                // this.framebuffer.drawPixelAntiAliased(x, y, color.toPackedFormat());
-                //}
-
-            }
-        }
     }
 
     /**
      * Triangle rasterization using edge-walking strategy for scan-conversion.
      * Internally DDA is used for edge-walking.
      */
-    public drawTriangleDDAOriginal(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
+    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
         if (p1.projection.y > p3.projection.y) {
             this.temp = p1;
             p1 = p3;
@@ -187,15 +67,6 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
                 this.fillLongLeftTriangle(p1, p2, p3);
             }
         }
-    }
-
-
-    /**
-     * Triangle rasterization using edge-walking strategy for scan-conversion.
-     * Internally DDA is used for edge-walking.
-     */
-    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
-        this.fillTriangle(p1, p2, p3);
     }
 
     private fillBottomFlatTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
@@ -309,11 +180,10 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
             const spanzStep = Math.round(this.curz2 - this.curz1) / length;
             let wStart = this.curz1;
             for (let j = 0; j < length; j++) {
-
                 const framebufferIndex = Math.round(this.yPosition) * this.framebuffer.width + Math.round(this.xPosition + j);
                 if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
                     this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.drawPixelAliased(this.xPosition + j, this.yPosition, color);
+                    this.framebuffer.framebuffer[framebufferIndex] = color;
                 }
                 wStart += spanzStep;
             }

--- a/src/rasterizer/FlatShadingTriangleRasterizer.ts
+++ b/src/rasterizer/FlatShadingTriangleRasterizer.ts
@@ -1,3 +1,5 @@
+import { Color } from '../core/Color';
+import { Utils } from '../core/Utils';
 import { Framebuffer } from '../Framebuffer';
 import { Vertex } from '../Vertex';
 import { AbstractTriangleRasterizer } from './AbstractTriangleRasterizer';
@@ -5,16 +7,133 @@ import { AbstractTriangleRasterizer } from './AbstractTriangleRasterizer';
 export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
 
     private temp: Vertex = null;
+    private slope1: number;
+    private slope2: number;
+    private zslope1: number;
+    private zslope2: number;
+    private curz1: number;
+    private curz2: number;
+    private xPosition: number;
+    private xPosition2: number;
+    private yPosition: number;
+
+    // create depth buffer
+    // use Uint16 because we only need a little precision and we save 2 bytes per pixel this way
+    private depthBuffer;
 
     constructor(private framebuffer: Framebuffer) {
         super();
+        this.depthBuffer = new Uint16Array(this.framebuffer.width * this.framebuffer.height)
+        // add some properties and methods to make using this easier
+        this.depthBuffer.width = this.framebuffer.width;
+        this.depthBuffer.height = this.framebuffer.height;
+        this.depthBuffer.clear = function () { this.fill(65535); };
+        this.depthBuffer.getDepth = function (x, y) { return this[y * this.width + x] / 65535.0; };
+        this.depthBuffer.setDepth = function (x, y, v) { this[y * this.width + x] = (v * 65535) | 0; };
+        this.depthBuffer.testDepth = function (x, y, v) {
+            const value = (v * 65535) | 0;
+            if (value < 0 || value > 65535) {
+                return false;
+            }
+            const index = y * this.width + x;
+            if (value < this[index]) {
+                this[index] = value;
+                return true;
+            }
+            return false;
+        };
+        this.depthBuffer.clear();
+    }
+
+    // returns true if vertices are in counterclockwise order
+    isCcw(v0, v1, v2) {
+        return (v1.x - v0.x) * (v2.y - v0.y) - (v1.y - v0.y) * (v2.x - v0.x) >= 0;
+    }
+
+    cross(a, b, c) {
+        return (b.x - a.x) * -(c.y - a.y) - -(b.y - a.y) * (c.x - a.x);
+    }
+
+    // https://kitsunegames.com/assets/software-3d-rendering-in-javascript-pt2/result/
+    public fillTriangle(v0, v1, v2, color: Color) {
+
+        if (this.isCcw(v0, v1, v2)) {
+            return;
+        }
+
+        const minX = Math.floor(Math.min(v0.x, v1.x, v2.x));
+        const maxX = Math.ceil(Math.max(v0.x, v1.x, v2.x));
+        const minY = Math.floor(Math.min(v0.y, v1.y, v2.y));
+        const maxY = Math.ceil(Math.max(v0.y, v1.y, v2.y));
+
+        // precalculate the area of the parallelogram defined by our triangle
+        const area = this.cross(v0, v1, v2);
+
+        // calculate edges
+        const edge0 = { x: v2.x - v1.x, y: v2.y - v1.y };
+        const edge1 = { x: v0.x - v2.x, y: v0.y - v2.y };
+        const edge2 = { x: v1.x - v0.x, y: v1.y - v0.y };
+
+        // calculate which edges are right edges so we can easily skip them
+        // right edges go up, or (bottom edges) are horizontal edges that go right
+        const edgeRight0 = edge0.y < 0 || (edge0.y === 0 && edge0.x > 0);
+        const edgeRight1 = edge1.y < 0 || (edge1.y === 0 && edge0.x > 0);
+        const edgeRight2 = edge2.y < 0 || (edge2.y === 0 && edge0.x > 0);
+
+        // p is our 2D pixel location point
+        const p = { x: null, y: null };
+
+        // fragment is the resulting pixel with all the vertex attributes interpolated
+        const fragment = {
+            r: undefined,
+            g: undefined,
+            b: undefined,
+            a: undefined,
+            z: null
+        };
+
+        for (let y = minY; y < maxY; y += .5) {
+            for (let x = minX; x < maxX; x += .5) {
+                // sample from the center of the pixel, not the top-left corner
+                p.x = x + 0.5; p.y = y + .5;
+
+                // calculate vertex weights
+                // should divide these by area, but we do that later
+                // so we divide once, not three times
+                const w0 = this.cross(v1, v2, p);
+                const w1 = this.cross(v2, v0, p);
+                const w2 = this.cross(v0, v1, p);
+
+                // if the point is not inside our polygon, skip fragment
+                if (w0 < 0 || w1 < 0 || w2 < 0) {
+                    continue;
+                }
+
+                // if this is a right or bottom edge, skip fragment (top-left rule):
+                if ((w0 === 0 && edgeRight0) || (w1 === 0 && edgeRight1) || (w2 === 0 && edgeRight2)) {
+                    continue;
+                }
+
+                // interpolate our vertices
+                fragment.r = (w0 * v0.r + w1 * v1.r + w2 * v2.r) / area;
+                fragment.g = (w0 * v0.g + w1 * v1.g + w2 * v2.g) / area;
+                fragment.b = (w0 * v0.b + w1 * v1.b + w2 * v2.b) / area;
+                fragment.a = (w0 * v0.x + w1 * v1.x + w2 * v2.x) / area;
+                fragment.z = (w0 * v0.z + w1 * v1.z + w2 * v2.z) / area;
+
+                // this can be optimized to only draw aliased pixels on the edges
+                this.framebuffer.drawPixelAntiAliasedSpacial(x, y, color.toPackedFormat());
+                // this.framebuffer.drawPixelAliased(x, y, color.toPackedFormat());
+
+            }
+        }
     }
 
     /**
      * Triangle rasterization using edge-walking strategy for scan-conversion.
      * Internally DDA is used for edge-walking.
      */
-    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
+    public drawTriangleDDAOriginal(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
         if (p1.projection.y > p3.projection.y) {
             this.temp = p1;
             p1 = p3;
@@ -41,245 +160,161 @@ export class FlatShadingTriangleRasterizer extends AbstractTriangleRasterizer {
                 p2 = p3;
                 p3 = this.temp;
             }
-            this.fillBottomFlatTriangle(framebuffer, p1, p2, p3);
+            this.fillBottomFlatTriangle(p1, p2, p3);
         } else if (p1.projection.y === p2.projection.y) {
             if (p1.projection.x > p2.projection.x) {
                 this.temp = p1;
                 p1 = p2;
                 p2 = this.temp;
             }
-            this.fillTopFlatTriangle(framebuffer, p1, p2, p3);
+            this.fillTopFlatTriangle(p1, p2, p3);
         } else {
             const x: number = (p3.projection.x - p1.projection.x) *
                 (p2.projection.y - p1.projection.y) / (p3.projection.y - p1.projection.y) + p1.projection.x;
             if (x > p2.projection.x) {
-                this.fillLongRightTriangle(framebuffer, p1, p2, p3);
+                this.fillLongRightTriangle(p1, p2, p3);
             } else {
-                this.fillLongLeftTriangle(framebuffer, p1, p2, p3);
+                this.fillLongLeftTriangle(p1, p2, p3);
             }
         }
     }
 
-    private fillBottomFlatTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
+
+    /**
+     * Triangle rasterization using edge-walking strategy for scan-conversion.
+     * Internally DDA is used for edge-walking.
+     */
+    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
+        this.fillTriangle(
+            { x: p1.projection.x, y: p1.projection.y, z: p1.projection.z },
+            { x: p2.projection.x, y: p2.projection.y, z: p2.projection.z },
+            { x: p3.projection.x, y: p3.projection.y, z: p3.projection.z }, p1.color)
+    }
+
+    private fillBottomFlatTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
         const color: number = v1.color.toPackedFormat();
 
         const yDistance: number = v3.projection.y - v1.projection.y;
 
-        const slope1: number = (v2.projection.x - v1.projection.x) / yDistance;
-        const slope2: number = (v3.projection.x - v1.projection.x) / yDistance;
+        this.slope1 = (v2.projection.x - v1.projection.x) / yDistance;
+        this.slope2 = (v3.projection.x - v1.projection.x) / yDistance;
 
-        const zslope1: number = (1 / v2.projection.z - 1 / v1.projection.z) / yDistance;
-        const zslope2: number = (1 / v3.projection.z - 1 / v1.projection.z) / yDistance;
+        this.zslope1 = (1 / v2.projection.z - 1 / v1.projection.z) / yDistance;
+        this.zslope2 = (1 / v3.projection.z - 1 / v1.projection.z) / yDistance;
 
-        let curz1: number = 1.0 / v1.projection.z;
-        let curz2: number = 1.0 / v1.projection.z;
+        this.curz1 = 1.0 / v1.projection.z;
+        this.curz2 = 1.0 / v1.projection.z;
 
-        let xPosition: number = v1.projection.x;
-        let xPosition2: number = v1.projection.x;
-        let yPosition: number = v1.projection.y;
+        this.xPosition = v1.projection.x;
+        this.xPosition2 = v1.projection.x;
+        this.yPosition = v1.projection.y;
 
-        for (let i = 0; i < yDistance; i++) {
-            const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
-            const spanzStep = (curz2 - curz1) / length;
-            let wStart = curz1;
-            for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = color;
-                }
-                framebufferIndex++;
-                wStart += spanzStep;
-            }
-
-            xPosition += slope1;
-            xPosition2 += slope2;
-            yPosition++;
-
-            curz1 += zslope1;
-            curz2 += zslope2;
-        }
+        this.drawSpan(yDistance, color);
     }
 
-    fillTopFlatTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
+    fillTopFlatTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
         const color: number = v1.color.toPackedFormat();
-
         const yDistance = v3.projection.y - v1.projection.y;
-        const slope1 = (v3.projection.x - v1.projection.x) / yDistance;
-        const slope2 = (v3.projection.x - v2.projection.x) / yDistance;
 
-        const zslope1 = (1 / v3.projection.z - 1 / v1.projection.z) / yDistance;
-        const zslope2 = (1 / v3.projection.z - 1 / v2.projection.z) / yDistance;
+        this.slope1 = (v3.projection.x - v1.projection.x) / yDistance;
+        this.slope2 = (v3.projection.x - v2.projection.x) / yDistance;
 
-        let curz1 = 1.0 / v1.projection.z;
-        let curz2 = 1.0 / v2.projection.z;
+        this.zslope1 = (1 / v3.projection.z - 1 / v1.projection.z) / yDistance;
+        this.zslope2 = (1 / v3.projection.z - 1 / v2.projection.z) / yDistance;
 
-        let xPosition = v1.projection.x;
-        let xPosition2 = v2.projection.x;
-        let yPosition = v1.projection.y;
+        this.curz1 = 1.0 / v1.projection.z;
+        this.curz2 = 1.0 / v2.projection.z;
 
-        for (let i = 0; i < yDistance; i++) {
-            const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
-            for (let j = 0; j < length; j++) {
-                const wStart = (curz2 - curz1) / (length) * j + curz1;
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = color;
-                }
-                framebufferIndex++;
-            }
+        this.xPosition = v1.projection.x;
+        this.xPosition2 = v2.projection.x;
+        this.yPosition = v1.projection.y;
 
-            xPosition += slope1;
-            xPosition2 += slope2;
-            yPosition++;
-
-            curz1 += zslope1;
-            curz2 += zslope2;
-        }
+        this.drawSpan(yDistance, color);
     }
 
-    fillLongRightTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
+
+    fillLongRightTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
         const color: number = v1.color.toPackedFormat();
 
         let yDistanceLeft = v2.projection.y - v1.projection.y;
         const yDistanceRight = v3.projection.y - v1.projection.y;
 
-        let slope1 = (v2.projection.x - v1.projection.x) / yDistanceLeft;
-        const slope2 = (v3.projection.x - v1.projection.x) / yDistanceRight;
+        this.slope1 = (v2.projection.x - v1.projection.x) / yDistanceLeft;
+        this.slope2 = (v3.projection.x - v1.projection.x) / yDistanceRight;
 
-        let zslope1 = (1 / v2.projection.z - 1 / v1.projection.z) / yDistanceLeft;
-        const zslope2 = (1 / v3.projection.z - 1 / v1.projection.z) / yDistanceRight;
+        this.zslope1 = (1 / v2.projection.z - 1 / v1.projection.z) / yDistanceLeft;
+        this.zslope2 = (1 / v3.projection.z - 1 / v1.projection.z) / yDistanceRight;
 
-        let curz1 = 1.0 / v1.projection.z;
-        let curz2 = 1.0 / v1.projection.z;
+        this.curz1 = 1.0 / v1.projection.z;
+        this.curz2 = 1.0 / v1.projection.z;
 
-        let xPosition = v1.projection.x;
-        let xPosition2 = v1.projection.x;
-        let yPosition = v1.projection.y;
+        this.xPosition = v1.projection.x;
+        this.xPosition2 = v1.projection.x;
+        this.yPosition = v1.projection.y;
 
-        for (let i = 0; i < yDistanceLeft; i++) {
-            const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
-            const spanzStep = (curz2 - curz1) / length;
-            let wStart = curz1;
-            for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = color;
-                }
-                framebufferIndex++;
-                wStart += spanzStep;
-            }
-
-            xPosition += slope1;
-            xPosition2 += slope2;
-            yPosition++;
-
-            curz1 += zslope1;
-            curz2 += zslope2;
-        }
+        this.drawSpan(yDistanceLeft, color);
 
         yDistanceLeft = v3.projection.y - v2.projection.y;
-        slope1 = (v3.projection.x - v2.projection.x) / yDistanceLeft;
-        zslope1 = (1 / v3.projection.z - 1 / v2.projection.z) / yDistanceLeft;
+        this.slope1 = (v3.projection.x - v2.projection.x) / yDistanceLeft;
+        this.zslope1 = (1 / v3.projection.z - 1 / v2.projection.z) / yDistanceLeft;
 
-        xPosition = v2.projection.x;
-        yPosition = v2.projection.y;
+        this.xPosition = v2.projection.x;
+        this.yPosition = v2.projection.y;
 
-        for (let i = 0; i < yDistanceLeft; i++) {
-            const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition)
-            const spanzStep = (curz2 - curz1) / length;
-            let wStart = curz1;
-            for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = color;
-                }
-                framebufferIndex++;
-                wStart += spanzStep;
-            }
-
-            xPosition += slope1;
-            xPosition2 += slope2;
-            yPosition++;
-
-            curz1 += zslope1;
-            curz2 += zslope2;
-        }
+        this.drawSpan(yDistanceLeft, color);
     }
 
-
-    fillLongLeftTriangle(framebuffer: Framebuffer, v1: Vertex, v2: Vertex, v3: Vertex): void {
+    fillLongLeftTriangle(v1: Vertex, v2: Vertex, v3: Vertex): void {
         const color: number = v1.color.toPackedFormat();
 
         let yDistanceRight = v2.projection.y - v1.projection.y;
         const yDistanceLeft = v3.projection.y - v1.projection.y;
 
-        let slope2 = (v2.projection.x - v1.projection.x) / yDistanceRight;
-        const slope1 = (v3.projection.x - v1.projection.x) / yDistanceLeft;
+        this.slope2 = (v2.projection.x - v1.projection.x) / yDistanceRight;
+        this.slope1 = (v3.projection.x - v1.projection.x) / yDistanceLeft;
 
-        let zslope2 = (1 / v2.projection.z - 1 / v1.projection.z) / yDistanceRight;
-        const zslope1 = (1 / v3.projection.z - 1 / v1.projection.z) / yDistanceLeft;
+        this.zslope2 = (1 / v2.projection.z - 1 / v1.projection.z) / yDistanceRight;
+        this.zslope1 = (1 / v3.projection.z - 1 / v1.projection.z) / yDistanceLeft;
 
-        let curz1 = 1.0 / v1.projection.z;
-        let curz2 = 1.0 / v1.projection.z;
+        this.curz1 = 1.0 / v1.projection.z;
+        this.curz2 = 1.0 / v1.projection.z;
 
-        let xPosition = v1.projection.x;
-        let xPosition2 = v1.projection.x;
-        let yPosition = v1.projection.y;
+        this.xPosition = v1.projection.x;
+        this.xPosition2 = v1.projection.x;
+        this.yPosition = v1.projection.y;
 
-        for (let i = 0; i < yDistanceRight; i++) {
-            const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition);
-            const spanzStep = (curz2 - curz1) / length;
-            let wStart = curz1;
-            for (let j = 0; j < length; j++) {
-                if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
-                    this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = color;
-                }
-                framebufferIndex++;
-                wStart += spanzStep;
-            }
-
-            xPosition += slope1;
-            xPosition2 += slope2;
-            yPosition++;
-
-            curz1 += zslope1;
-            curz2 += zslope2;
-        }
+        this.drawSpan(yDistanceRight, color);
 
         yDistanceRight = v3.projection.y - v2.projection.y;
-        slope2 = (v3.projection.x - v2.projection.x) / yDistanceRight;
-        zslope2 = (1 / v3.projection.z - 1 / v2.projection.z) / yDistanceRight;
+        this.slope2 = (v3.projection.x - v2.projection.x) / yDistanceRight;
+        this.zslope2 = (1 / v3.projection.z - 1 / v2.projection.z) / yDistanceRight;
 
-        curz2 = 1.0 / v2.projection.z;
-        xPosition2 = v2.projection.x;
-        yPosition = v2.projection.y;
+        this.curz2 = 1.0 / v2.projection.z;
+        this.xPosition2 = v2.projection.x;
+        this.yPosition = v2.projection.y;
 
-        for (let i = 0; i < yDistanceRight; i++) {
-            const length = Math.round(xPosition2) - Math.round(xPosition);
-            let framebufferIndex = Math.round(yPosition) * this.framebuffer.width + Math.round(xPosition)
-            const spanzStep = (curz2 - curz1) / length;
-            let wStart = curz1;
+        this.drawSpan(yDistanceRight, color);
+    }
+
+    drawSpan(distance: number, color: number) {
+        for (let i = 0; i < distance; i++) {
+            const length = (this.xPosition2) - (this.xPosition);
+            const spanzStep = Math.round(this.curz2 - this.curz1) / length;
+            let wStart = this.curz1;
             for (let j = 0; j < length; j++) {
+
+                const framebufferIndex = Math.round(this.yPosition) * this.framebuffer.width + Math.round(this.xPosition + j);
                 if (wStart < this.framebuffer.wBuffer[framebufferIndex]) {
                     this.framebuffer.wBuffer[framebufferIndex] = wStart;
-                    this.framebuffer.framebuffer[framebufferIndex] = color;
+                    this.framebuffer.drawPixelAliased(this.xPosition + j, this.yPosition, color);
                 }
-                framebufferIndex++;
                 wStart += spanzStep;
             }
-
-            xPosition += slope1;
-            xPosition2 += slope2;
-            yPosition++;
-
-            curz1 += zslope1;
-            curz2 += zslope2;
+            this.xPosition += this.slope1;
+            this.xPosition2 += this.slope2;
+            this.yPosition++;
+            this.curz1 += this.zslope1;
+            this.curz2 += this.zslope2;
         }
     }
 

--- a/src/rasterizer/SubPixelTriangleRasterizer.ts
+++ b/src/rasterizer/SubPixelTriangleRasterizer.ts
@@ -115,9 +115,9 @@ export class SubPixelTriangleRasterizer extends AbstractTriangleRasterizer {
 
                 // this can be optimized to only draw aliased pixels on the edges
 
-                 if (this.depthBuffer.testDepth(x, y, fragment.z)) {
+                // if (this.depthBuffer.testDepth(x, y, fragment.z)) {
                 this.framebuffer.drawPixelAntiAliasedSpacial(x, y, fragColor.toPackedFormat());
-                }
+                // }
 
             }
         }

--- a/src/rasterizer/SubPixelTriangleRasterizer.ts
+++ b/src/rasterizer/SubPixelTriangleRasterizer.ts
@@ -1,0 +1,135 @@
+import { Color } from '../core/Color';
+import { Framebuffer } from '../Framebuffer';
+import { Vertex } from '../Vertex';
+import { AbstractTriangleRasterizer } from './AbstractTriangleRasterizer';
+
+export class SubPixelTriangleRasterizer extends AbstractTriangleRasterizer {
+
+    // create depth buffer
+    // use Uint16 because we only need a little precision and we save 2 bytes per pixel this way
+    private depthBuffer;
+
+    constructor(private framebuffer: Framebuffer) {
+        super();
+        this.depthBuffer = new Uint16Array(this.framebuffer.width * this.framebuffer.height)
+        // add some properties and methods to make using this easier
+        this.depthBuffer.width = this.framebuffer.width;
+        this.depthBuffer.height = this.framebuffer.height;
+        this.depthBuffer.clear = function () { this.fill(65535); };
+        this.depthBuffer.getDepth = function (x, y) { return this[y * this.width + x] / 65535.0; };
+        this.depthBuffer.setDepth = function (x, y, v) { this[y * this.width + x] = (v * 65535) | 0; };
+        this.depthBuffer.testDepth = function (x, y, v) {
+            const value = (v * 65535) | 0;
+            if (value < 0 || value > 65535) {
+                return false;
+            }
+            const index = y * this.width + x;
+            if (value < this[index]) {
+                this[index] = value;
+                return true;
+            }
+            return false;
+        };
+        this.depthBuffer.clear();
+    }
+
+    // returns true if vertices are in counterclockwise order
+    isCcw(v0, v1, v2) {
+        return (v1.x - v0.x) * (v2.y - v0.y) - (v1.y - v0.y) * (v2.x - v0.x) >= 0;
+    }
+
+    cross(a, b, c) {
+        return (b.x - a.x) * -(c.y - a.y) - -(b.y - a.y) * (c.x - a.x);
+    }
+
+    // https://kitsunegames.com/assets/software-3d-rendering-in-javascript-pt2/result/
+    public fillTriangle(v0: Vertex, v1: Vertex, v2: Vertex) {
+
+        if (this.isCcw(v0.projection, v1.projection, v2.projection)) {
+            return;
+        }
+
+        const minX = Math.floor(Math.min(v0.projection.x, v1.projection.x, v2.projection.x));
+        const maxX = Math.ceil(Math.max(v0.projection.x, v1.projection.x, v2.projection.x));
+        const minY = Math.floor(Math.min(v0.projection.y, v1.projection.y, v2.projection.y));
+        const maxY = Math.ceil(Math.max(v0.projection.y, v1.projection.y, v2.projection.y));
+
+        // precalculate the area of the parallelogram defined by our triangle
+        const area = this.cross(v0.projection, v1.projection, v2.projection);
+
+        // calculate edges
+        const edge0 = { x: v2.projection.x - v1.projection.x, y: v2.projection.y - v1.projection.y };
+        const edge1 = { x: v0.projection.x - v2.projection.x, y: v0.projection.y - v2.projection.y };
+        const edge2 = { x: v1.projection.x - v0.projection.x, y: v1.projection.y - v0.projection.y };
+
+        // calculate which edges are right edges so we can easily skip them
+        // right edges go up, or (bottom edges) are horizontal edges that go right
+        const edgeRight0 = edge0.y < 0 || (edge0.y === 0 && edge0.x > 0);
+        const edgeRight1 = edge1.y < 0 || (edge1.y === 0 && edge0.x > 0);
+        const edgeRight2 = edge2.y < 0 || (edge2.y === 0 && edge0.x > 0);
+
+        // p is our 2D pixel location point
+        const p = { x: null, y: null };
+
+        // fragment is the resulting pixel with all the vertex attributes interpolated
+        const fragment = {
+            r: undefined,
+            g: undefined,
+            b: undefined,
+            a: undefined,
+            z: 0
+        };
+
+        for (let y = minY; y < maxY; y += .5) {
+            for (let x = minX; x < maxX; x += .5) {
+                // sample from the center of the pixel, not the top-left corner
+                p.x = x + 0.5; p.y = y + .5;
+
+                // calculate vertex weights
+                // should divide these by area, but we do that later
+                // so we divide once, not three times
+                const w0 = this.cross(v1.projection, v2.projection, p);
+                const w1 = this.cross(v2.projection, v0.projection, p);
+                const w2 = this.cross(v0.projection, v1.projection, p);
+
+                // if the point is not inside our polygon, skip fragment
+                if (w0 < 0 || w1 < 0 || w2 < 0) {
+                    continue;
+                }
+
+                // if this is a right or bottom edge, skip fragment (top-left rule):
+                if ((w0 === 0 && edgeRight0) || (w1 === 0 && edgeRight1) || (w2 === 0 && edgeRight2)) {
+                    continue;
+                }
+
+                // interpolate our vertices
+                fragment.r = (w0 * v0.color.r + w1 * v1.color.r + w2 * v2.color.r) / area;
+                fragment.g = (w0 * v0.color.g + w1 * v1.color.g + w2 * v2.color.g) / area;
+                fragment.b = (w0 * v0.color.b + w1 * v1.color.b + w2 * v2.color.b) / area;
+                fragment.a = (w0 * v0.projection.x + w1 * v1.projection.x + w2 * v2.projection.x) / area;
+                fragment.z = (w0 * v0.projection.z + w1 * v1.projection.z + w2 * v2.projection.z) / area;
+
+                const fragColor = new Color(
+                    fragment.r, fragment.g, fragment.b, fragment.a
+                )
+
+                // this can be optimized to only draw aliased pixels on the edges
+
+                 if (this.depthBuffer.testDepth(x, y, fragment.z)) {
+                this.framebuffer.drawPixelAntiAliasedSpacial(x, y, fragColor.toPackedFormat());
+                }
+
+            }
+        }
+    }
+
+    /**
+     * Triangle rasterization using edge-walking strategy for scan-conversion.
+     * Internally DDA is used for edge-walking.
+     */
+    public drawTriangleDDA(framebuffer: Framebuffer, p1: Vertex, p2: Vertex, p3: Vertex): void {
+        this.fillTriangle(p1, p2, p3);
+        // this.drawTriangleDDAOriginal(framebuffer, p1, p2, p3);
+    }
+
+}

--- a/src/rendering-pipelines/GouraudShadingRenderingPipeline.ts
+++ b/src/rendering-pipelines/GouraudShadingRenderingPipeline.ts
@@ -3,7 +3,6 @@ import { Framebuffer } from '../Framebuffer';
 import { FlatshadedMesh } from '../geometrical-objects/FlatshadedMesh';
 import { Vector4f } from '../math/index';
 import { Matrix4f } from '../math/Matrix4f';
-import { FlatShadingTriangleRasterizer } from '../rasterizer/FlatShadingTriangleRasterizer';
 import { SutherlandHodgman2DClipper } from '../screen-space-clipping/SutherlandHodgman2DClipper';
 import { Fog } from '../shading/fog/Fog';
 import { PhongLighting } from '../shading/illumination-models/PhongLighting';
@@ -12,6 +11,7 @@ import { Material } from '../shading/material/Material';
 import { Vertex } from '../Vertex';
 import { AbstractRenderingPipeline } from './AbstractRenderingPipeline';
 import { AbstractTriangleRasterizer } from '../rasterizer/AbstractTriangleRasterizer';
+import { GouraudShadingTriangleRasterizer } from '../rasterizer/GouraudShadingTriangleRasterizer';
 
 /**
  * TODO:
@@ -26,7 +26,7 @@ import { AbstractTriangleRasterizer } from '../rasterizer/AbstractTriangleRaster
  * - generate object only once
  * - dont use temp arrays / instead use always the same array preallocated
  */
-export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
+export class GouraudShadingRenderingPipeline extends AbstractRenderingPipeline {
 
     private fog: Fog = null;
     private lights: Array<PointLight> = null;
@@ -72,7 +72,7 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
         mat.shininess = 2;
 
         this.material = mat;
-        this.triangleRasterizer = new FlatShadingTriangleRasterizer(framebuffer);
+        this.triangleRasterizer = new GouraudShadingTriangleRasterizer(framebuffer);
     }
 
     public setFramebuffer(framebuffer: Framebuffer) {
@@ -182,15 +182,15 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
 
     public project(t1: { x: number, y: number, z: number }): Vector4f {
         return new Vector4f(
-            ((this.framebuffer.width / 2) + (292 * t1.x / (-t1.z))),
-            ((this.framebuffer.height / 2) - (t1.y * 292 / (-t1.z))),
+            Math.round((this.framebuffer.width / 2) + (292 * t1.x / (-t1.z))),
+            Math.round((this.framebuffer.height / 2) - (t1.y * 292 / (-t1.z))),
             t1.z
         );
     }
 
     public project2(t1: { x: number, y: number, z: number }, result: Vector4f): void {
-        result.x = ((this.framebuffer.width / 2) + (292 * t1.x / (-t1.z)));
-        result.y = ((this.framebuffer.height / 2) - (t1.y * 292 / (-t1.z)));
+        result.x = Math.round((this.framebuffer.width / 2) + (292 * t1.x / (-t1.z)));
+        result.y = Math.round((this.framebuffer.height / 2) - (t1.y * 292 / (-t1.z)));
         result.z = t1.z;
     }
 

--- a/src/rendering-pipelines/SubPixelRenderingPipeline.ts
+++ b/src/rendering-pipelines/SubPixelRenderingPipeline.ts
@@ -157,11 +157,6 @@ export class SubPixelRenderingPipeline extends AbstractRenderingPipeline {
                 if (output.length < 3) {
                     return;
                 }
-                /*
-                                const projected: Array<Vertex> = output.map<Vertex>((v: Vertex) => {
-                                    v.projection = this.project(v.position);
-                                    return v;
-                                });*/
 
                 for (let j: number = 0; j < output.length; j++) {
                     output[j].projection = this.project(output[j].position);

--- a/src/rendering-pipelines/SubPixelRenderingPipeline.ts
+++ b/src/rendering-pipelines/SubPixelRenderingPipeline.ts
@@ -3,7 +3,8 @@ import { Framebuffer } from '../Framebuffer';
 import { FlatshadedMesh } from '../geometrical-objects/FlatshadedMesh';
 import { Vector4f } from '../math/index';
 import { Matrix4f } from '../math/Matrix4f';
-import { FlatShadingTriangleRasterizer } from '../rasterizer/FlatShadingTriangleRasterizer';
+import { SubPixelTriangleRasterizer } from '../rasterizer/SubPixelTriangleRasterizer';
+
 import { SutherlandHodgman2DClipper } from '../screen-space-clipping/SutherlandHodgman2DClipper';
 import { Fog } from '../shading/fog/Fog';
 import { PhongLighting } from '../shading/illumination-models/PhongLighting';
@@ -15,18 +16,9 @@ import { AbstractTriangleRasterizer } from '../rasterizer/AbstractTriangleRaster
 
 /**
  * TODO:
- * - object with position, rotation, material, color
- * - remove tempp matrix objects: instead store one global MV  matrix and manipulate
- *   it directly without generating temp amtrices every frame
- * - no lighting for culled triangles
- * - only z clip if necessary (no clip, fully visible)
- * Optimization:
- * - no shading / only texture mapping (use function pointers to set correct rasterization function)
- * - use delta step method from black art of 3d programming
- * - generate object only once
- * - dont use temp arrays / instead use always the same array preallocated
+ * fix backface occlusion / add z-clipping
  */
-export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
+export class SubPixelRenderingPipeline extends AbstractRenderingPipeline {
 
     private fog: Fog = null;
     private lights: Array<PointLight> = null;
@@ -72,7 +64,7 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
         mat.shininess = 2;
 
         this.material = mat;
-        this.triangleRasterizer = new FlatShadingTriangleRasterizer(framebuffer);
+        this.triangleRasterizer = new SubPixelTriangleRasterizer(framebuffer);
     }
 
     public setFramebuffer(framebuffer: Framebuffer) {
@@ -182,15 +174,15 @@ export class FlatShadingRenderingPipeline extends AbstractRenderingPipeline {
 
     public project(t1: { x: number, y: number, z: number }): Vector4f {
         return new Vector4f(
-            Math.round((this.framebuffer.width / 2) + (292 * t1.x / (-t1.z))),
-            Math.round((this.framebuffer.height / 2) - (t1.y * 292 / (-t1.z))),
+            ((this.framebuffer.width / 2) + (292 * t1.x / (-t1.z))),
+            ((this.framebuffer.height / 2) - (t1.y * 292 / (-t1.z))),
             t1.z
         );
     }
 
     public project2(t1: { x: number, y: number, z: number }, result: Vector4f): void {
-        result.x = Math.round((this.framebuffer.width / 2) + (292 * t1.x / (-t1.z)));
-        result.y = Math.round((this.framebuffer.height / 2) - (t1.y * 292 / (-t1.z)));
+        result.x = ((this.framebuffer.width / 2) + (292 * t1.x / (-t1.z)));
+        result.y = ((this.framebuffer.height / 2) - (t1.y * 292 / (-t1.z)));
         result.z = t1.z;
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
 		'cinematic-scroller': './src/examples/cinematic-scroller/Application.ts',
 		'cube-tunnel': './src/examples/cube-tunnel/Application.ts',
 		'cube': './src/examples/cube/Application.ts',
+		'cube-subpixel': './src/examples/cube-subpixel/Application.ts',
 		'demo': './src/examples/demo/Application.ts',
 		'distorted-sphere': './src/examples/distorted-sphere/Application.ts',
         'dof-balls': './src/examples/dof-balls/Application.ts',
@@ -159,6 +160,11 @@ module.exports = {
 			template: './src/index.html',
 			chunks: ['cube'],
 			filename: 'cube.html'
+		}),
+        new HtmlWebpackPlugin({
+			template: './src/index.html',
+			chunks: ['cube-subpixel'],
+			filename: 'cube-subpixel.html'
 		}),
 		new HtmlWebpackPlugin({
 			template: './src/index.html',


### PR DESCRIPTION
Existing code
- separate FlatShading vs GouraudShading rending pipelines into their own files
- FlatShadingRenderingPipeline uses FlatShadingTriangleRasterizer
- GouraudShadingRenderingPipeline uses GouraudShadingTriangleRasterizer 
- rename scenes incorrectly using flatshading -> gouradshading
- reduce code used by both FlatShadingTriangleRasterizer & GouraudShadingTriangleRasterizer by using drawSpan method

Subpixel
- add experimental subpixel rendering pipeline (cube-subpixel.html)
- add fractional pixel plotting functions to framebuffer.ts
- SubPixelRenderingPipeline uses SubPixelTriangleRasterizer
 
![sub_cube](https://user-images.githubusercontent.com/2692017/152673497-b1a51357-c9de-479f-9592-9d049d965949.png)
![sub_torus](https://user-images.githubusercontent.com/2692017/152673498-31c48be9-23f9-443a-a1ef-143f52909718.png)

